### PR TITLE
Fix operator references that were directing to Python docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,10 +32,10 @@ Who's this for?
 ---------------
 Jupyter Enterprise Gateway is a highly technical piece of the Jupyter Stack, so we've separated documentation to help specific personas:
 
-1. :ref:`Users <users>`: people using Jupyter web applications that wish to connect to an Enterprise Gateway instance.
-2. :ref:`Operators <operators>`: people deploying or serving Jupyter Enterprise Gateway to others.
-3. :ref:`Developers <developers>`: people writing applications or deploying kernels for other resource managers.
-4. :ref:`Contributors <contributors>`: people contributing directly to the Jupyter Enterprise Gateway project.
+1. `Users <users/index.html>`_: people using Jupyter web applications that wish to connect to an Enterprise Gateway instance.
+2. `Operators <operators/index.html>`_: people deploying or serving Jupyter Enterprise Gateway to others.
+3. `Developers <developers/index.html>`_: people writing applications or deploying kernels for other resource managers.
+4. `Contributors <contributors/index.html>`_: people contributing directly to the Jupyter Enterprise Gateway project.
 
 If you find gaps in our documentation, please open an issue (or better yet, a pull request) on the Jupyter Enterprise Gateway `Github repo <https://github.com/jupyter-server/enterprise_gateway>`_.
 

--- a/docs/source/users/index.rst
+++ b/docs/source/users/index.rst
@@ -9,7 +9,7 @@ Because Enterprise Gateway is a headless web server, it is typically accessed fr
 
     - *As a student, my Data Science 101 course is leveraging GPUs in our experiments.  Since GPUs are expensive, we must share resources within the university's compute cluster and configure our Notebooks to leverage the department's Enterprise Gateway server, which can then spawn container-based kernels that have access to a GPU on Kubernetes.*
 
-The following assumes an Enterprise Gateway server has been configured and deployed.  Please consult the :ref:`operators <operators>` documentation to deploy and configure the Enterprise Gateway server.
+The following assumes an Enterprise Gateway server has been configured and deployed.  Please consult the `operators <../operators/index.html>`_ documentation to deploy and configure the Enterprise Gateway server.
 
 .. note::
   There are two primary client applications that can use Enterprise Gateway, JupyterLab running on Jupyter Server and Jupyter Notebook.  When a reference to a *Jupyter server* (lowercase 'server') or *the server* is made, the reference applies to both Jupyter Server and Jupyter Notebook.  Generally speaking, the client-side behaviors are identical between the two, although references to Jupyter Server are preferred since it's more current.  If anything is different, that difference will be noted, otherwise, please assume discussion of the two are interchangeable.


### PR DESCRIPTION
Just discovered that references meant to link to the `Operators Guide` (`operators/index.rst`) were hitting the Python operators documentation, presumably because I didn't have a reference to `name: operators` in the `index.rst`.  Since other links to various "role" `index.rst` were also a little funky relative to where the link placed the focus, I updated those as well.