### PR TITLE
Fix build to propagate SA macro between makefiles

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -5,7 +5,7 @@
     clean-kernel-images clean-py clean-tf-py clean-tf-gpu-py clean-r clean-spark-r clean-scala toree-launcher \
     kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker clean-kernel-image-puller
 
-SA:=source activate
+SA?=source activate
 ENV:=enterprise-gateway-dev
 SHELL:=/bin/bash
 


### PR DESCRIPTION
Turns out our build has been broken since December of 2020!  The issue is that, at that time, we introduced the `SA` macro on the command line to indicate the `source activate` command to use when switching into the conda env used by the make targets and properly declared that macro in the primary `Makefile` as:
```
SA?=source activate
```
The problem occurs when building the `enterprise-gateway-demo` image.  In that case, the upper `Makefile` invokes the `etc/Makefile` which then needs to invoke a target back in the parent `Makefile`.  Since the `etc/Makefile` defined `SA` as:
```
SA:=source activate
```
the command line version gets unset and the command invoked in the parent Makefile fails with:
```
make[3]: Entering directory '/home/runner/work/enterprise_gateway/enterprise_gateway'
source activate enterprise-gateway-dev && flake8 enterprise_gateway
/bin/bash: activate: No such file or directory
make[3]: *** [Makefile:57: lint] Error 1
make[2]: *** [Makefile:128: TARGETS_enterprise-gateway-demo] Error 2
make[1]: *** [Makefile:155: ../.image-enterprise-gateway-demo] Error 2
make[3]: Leaving directory '/home/runner/work/enterprise_gateway/enterprise_gateway'
make[2]: Leaving directory '/home/runner/work/enterprise_gateway/enterprise_gateway/etc'
make: *** [Makefile:132: enterprise-gateway-demo] Error 2
make[1]: Leaving directory '/home/runner/work/enterprise_gateway/enterprise_gateway/etc'
```
This causes the build for the `elyra/enterprise-gateway-demo:dev` image to fail.  Fortunately, until just recently, the proper version of that image was present on docker hub, but it would NOT contain the correct version of enterprise gateway.  As a result, we've been using an older version of enterprise gateway for our integration tests. 

This change amends the `SA` macro definition in `etc/Makefile` and results in a successful build of `enterprise-gateway-demo:dev` which is then used in the integration tests.
