### PR TITLE
Attempt to fix FD leak issue #1051

### DIFF
--- a/docs/source/operators/config-env-debug.md
+++ b/docs/source/operators/config-env-debug.md
@@ -27,6 +27,10 @@ The following environment variables may be useful for troubleshooting:
   EG_POLL_INTERVAL=0.5
     The interval (in seconds) to wait before checking poll results again.
 
+  EG_RESTART_STATUS_POLL_INTERVAL=1.0
+    The interval (in seconds) to wait before polling for the restart status again when duplicate restart request
+    for the same kernel is received or when a shutdown request is received while kernel is still restarting.
+
   EG_REMOVE_CONTAINER=True
     Used by launch_docker.py, indicates whether the kernel's docker container should be
     removed following its shutdown.  Set this value to 'False' if you want the container

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -562,6 +562,10 @@ class RemoteKernelManager(EnterpriseGatewayConfigMixin, AsyncIOLoopKernelManager
             Any options specified here will overwrite those used to launch the
             kernel.
         """
+        # this is added for only auto-restarter as it directly call this method.
+        self.log.info(f"restarting kernel with value for now: {now}")
+        if now:
+            self.restarting = True
         kernel_id = self.kernel_id or os.path.basename(self.connection_file).replace(
             "kernel-", ""
         ).replace(".json", "")
@@ -592,6 +596,8 @@ class RemoteKernelManager(EnterpriseGatewayConfigMixin, AsyncIOLoopKernelManager
         # Refresh persisted state.
         if self.kernel_session_manager:
             self.kernel_session_manager.refresh_session(kernel_id)
+        if now:
+            self.restarting = False
 
     async def signal_kernel(self, signum):
         """

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -23,7 +23,6 @@ default_kernel_launch_timeout = float(os.getenv("EG_KERNEL_LAUNCH_TIMEOUT", "30"
 kernel_restart_status_poll_interval = float(os.getenv("EG_RESTART_STATUS_POLL_INTERVAL", 1.0))
 
 
-
 def import_item(name):
     """Import and return ``bar`` given the string ``foo.bar``.
     Calling ``bar = import_item("foo.bar")`` is the functional equivalent of
@@ -264,7 +263,7 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
             if self.parent.max_kernels_per_user >= 0:
                 if self.parent.kernel_session_manager:
                     active_and_pending = (
-                            self.parent.kernel_session_manager.active_sessions(username) + pending_user
+                        self.parent.kernel_session_manager.active_sessions(username) + pending_user
                     )
                     if active_and_pending >= self.parent.max_kernels_per_user:
                         error_message = (
@@ -288,7 +287,7 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
         self.parent.kernel_session_manager.delete_session(kernel_id)
 
     def start_kernel_from_session(
-            self, kernel_id, kernel_name, connection_info, process_info, launch_args
+        self, kernel_id, kernel_name, connection_info, process_info, launch_args
     ):
         """
         Starts a kernel from a persisted kernel session.
@@ -460,7 +459,9 @@ class RemoteKernelManager(EnterpriseGatewayConfigMixin, AsyncIOLoopKernelManager
         """
         env = kwargs.get("env", {})
         # If KERNEL_LAUNCH_TIMEOUT is passed in the payload, override it.
-        self.kernel_launch_timeout = float(env.get("KERNEL_LAUNCH_TIMEOUT", default_kernel_launch_timeout))
+        self.kernel_launch_timeout = float(
+            env.get("KERNEL_LAUNCH_TIMEOUT", default_kernel_launch_timeout)
+        )
         self.user_overrides.update(
             {
                 key: value

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -1,13 +1,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 """Kernel managers that operate against a remote process."""
-import time
-
 import asyncio
-
 import os
 import re
 import signal
+import time
 import uuid
 
 from jupyter_client.ioloop.manager import AsyncIOLoopKernelManager
@@ -21,7 +19,7 @@ from enterprise_gateway.mixins import EnterpriseGatewayConfigMixin
 from ..processproxies.processproxy import LocalProcessProxy, RemoteProcessProxy
 from ..sessions.kernelsessionmanager import KernelSessionManager
 
-default_kernel_launch_timeout = float(os.getenv('EG_KERNEL_LAUNCH_TIMEOUT', '30'))
+default_kernel_launch_timeout = float(os.getenv("EG_KERNEL_LAUNCH_TIMEOUT", "30"))
 
 
 def import_item(name):
@@ -201,12 +199,13 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
             await self.wait_for_restart_finish(kernel_id, "restart")
             self.log.info(
                 f"Done with waiting for restart to complete. Current value of kernel.restarting: {kernel.restarting}. "
-                f"Skipping kernel restart.")
+                f"Skipping kernel restart."
+            )
             return
         self.log.info("Going ahead to process kernel restart request.")
         try:
             kernel.restarting = True  # Moved in out of RemoteKernelManager
-            await super(RemoteMappingKernelManager, self).restart_kernel(kernel_id)
+            await super().restart_kernel(kernel_id)
         finally:
             self.log.debug("Resetting kernel.restarting flag to False.")
             kernel.restarting = False
@@ -217,7 +216,7 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
         if kernel.restarting:
             await self.wait_for_restart_finish(kernel_id, "shutdown")
         try:
-            await super(RemoteMappingKernelManager, self).shutdown_kernel(kernel_id, now, restart)
+            await super().shutdown_kernel(kernel_id, now, restart)
         except KeyError as ke:  # this is hit for multiple shutdown request.
             self.log.exception(f"Exception while shutting Kernel: {kernel_id}: {ke}")
 
@@ -226,16 +225,22 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
         start_time = float(time.time())  # epoc time
         timeout = kernel.kernel_launch_timeout
         poll_time = 1  # TODO can be read from a new config if need be.
-        self.log.info(f"kernel is restarting when {action} request received. Polling every {poll_time} "
-                      f"seconds for next {timeout} seconds for kernel '{kernel_id}'"
-                      f" to complete its restart.")
+        self.log.info(
+            f"kernel is restarting when {action} request received. Polling every {poll_time} "
+            f"seconds for next {timeout} seconds for kernel '{kernel_id}'"
+            f" to complete its restart."
+        )
         while kernel.restarting:
             now = float(time.time())
             if (now - start_time) > timeout:
-                self.log.info(f"Wait_Timeout: Existing out of the restart wait loop to {action} kernel.")
+                self.log.info(
+                    f"Wait_Timeout: Existing out of the restart wait loop to {action} kernel."
+                )
                 break
             await asyncio.sleep(poll_time)
-        self.log.info(f"Returning with current value of the kernel.restarting: {kernel.restarting}.")
+        self.log.info(
+            f"Returning with current value of the kernel.restarting: {kernel.restarting}."
+        )
         return
 
     def _enforce_kernel_limits(self, username: str) -> None:
@@ -463,8 +468,8 @@ class RemoteKernelManager(EnterpriseGatewayConfigMixin, AsyncIOLoopKernelManager
         """
         env = kwargs.get("env", {})
         # see if KERNEL_LAUNCH_TIMEOUT was included from user.  If so, override default
-        if env.get('KERNEL_LAUNCH_TIMEOUT', None):
-            self.kernel_launch_timeout = float(env.get('KERNEL_LAUNCH_TIMEOUT'))
+        if env.get("KERNEL_LAUNCH_TIMEOUT", None):
+            self.kernel_launch_timeout = float(env.get("KERNEL_LAUNCH_TIMEOUT"))
         self.user_overrides.update(
             {
                 key: value

--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -142,8 +142,10 @@ class ContainerProcessProxy(RemoteProcessProxy):
         container_status = self.get_container_status(None)
         # Do not check whether container_status is None
         # EG couldn't restart kernels although connections exists.
-        # See https://github.com/jupyter-server/enterprise_gateway/issues/827
-        if container_status in self.get_initial_states():
+        # See https://github.com/jupyter/enterprise_gateway/issues/827
+        # The new check for `kernel_manager.restarting` added to prevent that false positive
+        # response that might happen when the kernel is restarting.
+        if self.kernel_manager.restarting or container_status in self.get_initial_states():
             result = None
 
         return result

--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -142,10 +142,8 @@ class ContainerProcessProxy(RemoteProcessProxy):
         container_status = self.get_container_status(None)
         # Do not check whether container_status is None
         # EG couldn't restart kernels although connections exists.
-        # See https://github.com/jupyter/enterprise_gateway/issues/827
-        # The new check for `kernel_manager.restarting` added to prevent that false positive
-        # response that might happen when the kernel is restarting.
-        if self.kernel_manager.restarting or container_status in self.get_initial_states():
+        # See https://github.com/jupyter-server/enterprise_gateway/issues/827
+        if container_status in self.get_initial_states():
             result = None
 
         return result


### PR DESCRIPTION
## Description
This PR is raised wrt the fix proposed in #1051  to wait on the Kernel Shutdown request until the kernel Restart is completed. 
- the fix is made only on EG as it depends on the Kernel field set with in the EG code only: [kernel.restarting](https://github.com/jupyter-server/enterprise_gateway/blob/master/enterprise_gateway/services/kernels/remotemanager.py#L488)
-  There are some TODOs and open items which are open for discussion. (done)
- The time used to wait for restart to complete is inherited / taken from "KERNEL_LAUNCH_TIMEOUT" as this is precisely the time which even the kernel start would wait before giving up on the kernel.  

## How does this prevent the FD leak mentioned on #1051 ?
- As we are waiting on the restart to complete and no going to allow shutdown to happen in parallel, the chances of Shutdown flow terminating the kernel at the exact same time when Kernel restart is waiting on `kernel_info` is minimal. 
- This also prevents any other accidental leaks that might happen if a shutdown request is processed while Restart is happening. 

## TESTING 
- I have done some basic sanity testing with notebook and JupyterLab and  it looks to be working fine. 

- Tested the changes on local python kernel and changes seems to be working as expected. 
- when a restart request is followed by shutdown, the shutdown request waits until the restart is completed and then shuts down the kernel cleanly.
- when a restart request is followed by shutdown and the shutdown times out waiting, it proceeds to forceful shutdown. This was the same behaviour before the current changes were made.
- when multiple restart request is received for the same kernel, the first shutdown request goes the actual restart while all the other duplicate request wait for the `kernel.restarting` to become `False` and return. 
thanks!

### Test Scenario : Kernel is restarted via "auto restarter". And then kernel restart request is sent.

```
# the kernel was already running and we forcefully killed the kernel process.
# this trigger the auto-restarter 
 
AsyncIOLoopKernelRestarter: restarting kernel (1/5), keep random ports
kernel 0fb50ca9-b8ee-4030-9207-958ff3bab86a restarted
 
restarting kernel with value for now: True

Instantiating kernel 'Python 3 (ipykernel)' with process proxy: enterprise_gateway.services.processproxies.processproxy.LocalProcessProxy
Starting kernel (async): ['/Users/rhgoyal/miniconda3/envs/enterprise-gateway-dev/bin/python', '-m', 'ipykernel_launcher', '-f', '/Users/rhgoyal/Library/Jupyter/runtime/kernel-0fb50ca9-b8ee-4030-9207-958ff3bab86a.json']
Launching kernel: 'Python 3 (ipykernel)' with command: ['/Users/rhgoyal/miniconda3/envs/enterprise-gateway-dev/bin/python', '-m', 'ipykernel_launcher', '-f', '/Users/rhgoyal/Library/Jupyter/runtime/kernel-0fb50ca9-b8ee-4030-9207-958ff3bab86a.json']
BaseProcessProxy.launch_process() env: {'PATH': '/usr/local/opt/scala@2.12/bin:/Users/rhgoyal/miniconda3/envs/enterprise-gateway-dev/bin:/Users/rhgoyal/miniconda3/condabin:/Users/rhgoyal/miniconda3/bin:/Users/rhgoyal/learning/installs/apache-maven-3.6.3/bin:/Users/rhgoyal/.toolbox/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin', 'KERNEL_EXTRA_SPARK_OPTS': ' --conf spark.kubernetes.executor.label.component=worker ', 'KERNEL_LAUNCH_TIMEOUT': '150', 'KERNEL_WORKING_DIR': '/Users/rhgoyal/learning/k8s/jupyter', 'KERNEL_USERNAME': 'rhgoyal', 'KERNEL_GATEWAY': '1', 'KERNEL_ID': '0fb50ca9-b8ee-4030-9207-958ff3bab86a', 'KERNEL_LANGUAGE': 'python', 'EG_IMPERSONATION_ENABLED': 'False'}
Local kernel launched on '192.168.0.106', pid: 65658, pgid: 65658, KernelID: 0fb50ca9-b8ee-4030-9207-958ff3bab86a, cmd: '['/Users/rhgoyal/miniconda3/envs/enterprise-gateway-dev/bin/python', '-m', 'ipykernel_launcher', '-f', '/Users/rhgoyal/Library/Jupyter/runtime/kernel-0fb50ca9-b8ee-4030-9207-958ff3bab86a.json']'
Connecting to: tcp://127.0.0.1:51321
Refreshing kernel session for id: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (busy)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (idle)
AsyncIOLoopKernelRestarter: restart apparently succeeded



Websocket closed 0fb50ca9-b8ee-4030-9207-958ff3bab86a:d78a447e-56649b2aad7998e7efa537be
Starting buffering for 0fb50ca9-b8ee-4030-9207-958ff3bab86a:d78a447e-56649b2aad7998e7efa537be
Clearing buffer for 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Initializing websocket connection /api/kernels/0fb50ca9-b8ee-4030-9207-958ff3bab86a/channels
No session ID specified
Opening websocket /api/kernels/0fb50ca9-b8ee-4030-9207-958ff3bab86a/channels
Getting buffer for 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Clearing buffer for 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Connecting to: tcp://127.0.0.1:51318
Connecting to: tcp://127.0.0.1:51317
Connecting to: tcp://127.0.0.1:51321
Connecting to: tcp://127.0.0.1:51319
Connecting to: tcp://127.0.0.1:51317
Connecting to: tcp://127.0.0.1:51321
Nudge: attempt 1 on kernel 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Nudge: IOPub received: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Nudge: resolving iopub future: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (busy)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (idle)
Nudge: shell info reply received: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Nudge: resolving shell future: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (busy)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (idle)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (busy)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (idle)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (busy)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: comm_close
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (idle)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (busy)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (idle)




Websocket closed 0fb50ca9-b8ee-4030-9207-958ff3bab86a:93c6b3dd-fe2911af8651bfe9c58bd8f9
Starting buffering for 0fb50ca9-b8ee-4030-9207-958ff3bab86a:93c6b3dd-fe2911af8651bfe9c58bd8f9
Clearing buffer for 0fb50ca9-b8ee-4030-9207-958ff3bab86a

# received restart from User / UI
Current value of the kernel.restarting: False
Going ahead to process kernel restart request.
restarting kernel with value for now: False
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (busy)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: shutdown_reply
Buffering msg on 0fb50ca9-b8ee-4030-9207-958ff3bab86a:iopub
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (idle)
Buffering msg on 0fb50ca9-b8ee-4030-9207-958ff3bab86a:iopub
Buffering msg on 0fb50ca9-b8ee-4030-9207-958ff3bab86a:iopub
Instantiating kernel 'Python 3 (ipykernel)' with process proxy: enterprise_gateway.services.processproxies.processproxy.LocalProcessProxy
Starting kernel (async): ['/Users/rhgoyal/miniconda3/envs/enterprise-gateway-dev/bin/python', '-m', 'ipykernel_launcher', '-f', '/Users/rhgoyal/Library/Jupyter/runtime/kernel-0fb50ca9-b8ee-4030-9207-958ff3bab86a.json']
Launching kernel: 'Python 3 (ipykernel)' with command: ['/Users/rhgoyal/miniconda3/envs/enterprise-gateway-dev/bin/python', '-m', 'ipykernel_launcher', '-f', '/Users/rhgoyal/Library/Jupyter/runtime/kernel-0fb50ca9-b8ee-4030-9207-958ff3bab86a.json']
BaseProcessProxy.launch_process() env: {'PATH': '/usr/local/opt/scala@2.12/bin:/Users/rhgoyal/miniconda3/envs/enterprise-gateway-dev/bin:/Users/rhgoyal/miniconda3/condabin:/Users/rhgoyal/miniconda3/bin:/Users/rhgoyal/learning/installs/apache-maven-3.6.3/bin:/Users/rhgoyal/.toolbox/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin', 'KERNEL_EXTRA_SPARK_OPTS': ' --conf spark.kubernetes.executor.label.component=worker ', 'KERNEL_LAUNCH_TIMEOUT': '150', 'KERNEL_WORKING_DIR': '/Users/rhgoyal/learning/k8s/jupyter', 'KERNEL_USERNAME': 'rhgoyal', 'KERNEL_GATEWAY': '1', 'KERNEL_ID': '0fb50ca9-b8ee-4030-9207-958ff3bab86a', 'KERNEL_LANGUAGE': 'python', 'EG_IMPERSONATION_ENABLED': 'False'}
Local kernel launched on '192.168.0.106', pid: 65678, pgid: 65678, KernelID: 0fb50ca9-b8ee-4030-9207-958ff3bab86a, cmd: '['/Users/rhgoyal/miniconda3/envs/enterprise-gateway-dev/bin/python', '-m', 'ipykernel_launcher', '-f', '/Users/rhgoyal/Library/Jupyter/runtime/kernel-0fb50ca9-b8ee-4030-9207-958ff3bab86a.json']'
Connecting to: tcp://127.0.0.1:51321
Refreshing kernel session for id: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Kernel restarted: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Connecting to: tcp://127.0.0.1:51317
Resetting kernel.restarting flag to False.
Initializing websocket connection /api/kernels/0fb50ca9-b8ee-4030-9207-958ff3bab86a/channels
No session ID specified
Opening websocket /api/kernels/0fb50ca9-b8ee-4030-9207-958ff3bab86a/channels
Getting buffer for 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Clearing buffer for 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Discarding 3 buffered messages for 0fb50ca9-b8ee-4030-9207-958ff3bab86a:93c6b3dd-fe2911af8651bfe9c58bd8f9
Connecting to: tcp://127.0.0.1:51318
Connecting to: tcp://127.0.0.1:51317
Connecting to: tcp://127.0.0.1:51321
Connecting to: tcp://127.0.0.1:51319
Connecting to: tcp://127.0.0.1:51317
Connecting to: tcp://127.0.0.1:51321
Nudge: attempt 1 on kernel 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Nudge: attempt 2 on kernel 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Nudge: IOPub received: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Nudge: resolving iopub future: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Nudge: shell info reply received: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
Nudge: resolving shell future: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (busy)
activity on 0fb50ca9-b8ee-4030-9207-958ff3bab86a: status (idle)
Kernel info reply received: 0fb50ca9-b8ee-4030-9207-958ff3bab86a
``` 
