### PR TITLE
Fix up some docker image README issues (minor)

### DIFF
--- a/etc/docker/enterprise-gateway/README.md
+++ b/etc/docker/enterprise-gateway/README.md
@@ -15,9 +15,9 @@ Download the [enterprise-gateway.yaml](https://github.com/jupyter-server/enterpr
 Deploy Jupyter Enterprise Gateway using `kubectl apply -f enterprise-gateway.yaml`
 
 ## Docker Swarm
-Download the [docker-compose.yml](https://github.com/jupyter-server/enterprise_gateway/blob/master/etc/docker/docker-compose.yml) file and make any necessary changes for your configuration. The compose file consists of three pieces, the Enterprise Gateway container itself, a proxy layer container, and a Docker network.  We recommend that a volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+Download the [`docker-compose.yml`](https://github.com/jupyter-server/enterprise_gateway/blob/master/etc/docker/docker-compose.yml) file and make any necessary changes for your configuration. The compose file consists of three pieces, the Enterprise Gateway container itself, a proxy layer container, and a Docker network.  We recommend that a volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
 
 ## Docker (Traditional)
-Same instructions as for Docker Swarm using [docker-compose.yml](https://github.com/jupyter-server/enterprise_gateway/blob/master/etc/docker/docker-compose.yml).  Please note that you can still run Enterprise Gateway as a traditional docker container within a Docker Swarm cluster, yet have the kernel containers launched as Docker Swarm services since how the kernels are launched is a function of their configured process proxy class.
+Same instructions as for Docker Swarm using [`docker-compose.yml`](https://github.com/jupyter-server/enterprise_gateway/blob/master/etc/docker/docker-compose.yml).  Please note that you can still run Enterprise Gateway as a traditional docker container within a Docker Swarm cluster, yet have the kernel containers launched as Docker Swarm services since how the kernels are launched is a function of their configured process proxy class.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kernel-spark-py/README.md
+++ b/etc/docker/kernel-spark-py/README.md
@@ -8,6 +8,6 @@ This image enables the use of an IPython kernel launched from [Jupyter Enterpris
 # Basic Use
 Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) per its instructions and configured to the appropriate environment.
 
-Launch a gateway-enabled Jupyter Notebook application against  the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
+Launch a gateway-enabled Jupyter Notebook application against the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kernel-spark-r/README.md
+++ b/etc/docker/kernel-spark-r/README.md
@@ -7,6 +7,6 @@ This image enables the use of an IRKernel kernel launched from [Jupyter Enterpri
 # Basic Use
 Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) per its instructions and configured to the appropriate environment.
 
-Launch a gateway-enabled Jupyter Notebook application against  the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
+Launch a gateway-enabled Jupyter Notebook application against the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kernel-tf-gpu-py/README.md
+++ b/etc/docker/kernel-tf-gpu-py/README.md
@@ -1,11 +1,11 @@
 This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster that can perform Tensorflow operations.  It is currently built on [tensorflow/tensorflow:2.7.0-gpu-jupyter](https://hub.docker.com/r/tensorflow/tensorflow/) deriving from the [tensorflow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/README.md) project.
 
 # What it Gives You
-* IPython kernel support supplemented with Tensorflow functionality (and deubugger)
+* IPython kernel support supplemented with Tensorflow functionality (and debugger)
 
 # Basic Use
 Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) per its instructions and configured to the appropriate environment.
 
-Launch a gateway-enabled Jupyter Notebook application against  the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
+Launch a gateway-enabled Jupyter Notebook application against the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kernel-tf-py/README.md
+++ b/etc/docker/kernel-tf-py/README.md
@@ -6,6 +6,6 @@ This image enables the use of an IPython kernel launched from [Jupyter Enterpris
 # Basic Use
 Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) per its instructions and configured to the appropriate environment.
 
-Launch a gateway-enabled Jupyter Notebook application against  the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
+Launch a gateway-enabled Jupyter Notebook application against the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/). 


### PR DESCRIPTION
When applying the changes from #1049 to the dockerhub image README descriptions, Grammarly reported on some (very minor) issues that I felt should just be handled.  Mostly its a double-space issue, but there was a typo it also found.