### PR TITLE
Bump jinja2 dependency floor

### DIFF
--- a/enterprise_gateway/services/kernelspecs/kernelspec_cache.py
+++ b/enterprise_gateway/services/kernelspecs/kernelspec_cache.py
@@ -267,7 +267,7 @@ class KernelSpecChangeHandler(FileSystemEventHandler):
             self.kernel_spec_cache.put_item(kernel_name, kernelspec)
         except Exception as e:
             self.log.warning("The following exception occurred updating cache entry for: {src_resource_dir} "
-                             "- continuing...  ({e})".format(src_resource_dir=event.src_src_resource_dir, e=e))
+                             "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e))
 
     def on_moved(self, event):
         """Fires when a watched file is moved.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ Apache Spark, Kubernetes and others..
     install_requires=[
         'docker>=3.5.0',
         'future',
-        'jinja2>=2.10',
+        'jinja2>=3.1',
         'jupyter_client~=6.1',
         'jupyter_core>=4.6.0',
         'kubernetes>=4.0.0',


### PR DESCRIPTION
The EG integration tests have been timing out waiting for EG to start.  It turns out this was due to a recent change to `markupsafe` which removed a method used by older versions of `jinja2`.  Since the `elyra/demo-base:2.4.6` image has `jinja2==2.11.2` installed and EG required `>=2.10`, a newer version of Jinja2 was not installed, producing this issue when EG goes to start...
```
Waiting for enterprise-gateway to start...
2022-04-04T18:16:08.380142789Z     from jinja2 import Environment, FileSystemLoader
2022-04-04T18:16:08.380146289Z   File "/opt/conda/lib/python3.7/site-packages/jinja2/__init__.py", line 12, in <module>
2022-04-04T18:16:08.380162289Z     from .environment import Environment
2022-04-04T18:16:08.380166389Z   File "/opt/conda/lib/python3.7/site-packages/jinja2/environment.py", line 25, in <module>
2022-04-04T18:16:08.380169989Z     from .defaults import BLOCK_END_STRING
2022-04-04T18:16:08.380300790Z   File "/opt/conda/lib/python3.7/site-packages/jinja2/defaults.py", line 3, in <module>
2022-04-04T18:16:08.380308190Z     from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
2022-04-04T18:16:08.380311890Z   File "/opt/conda/lib/python3.7/site-packages/jinja2/filters.py", line 13, in <module>
2022-04-04T18:16:08.380315990Z     from markupsafe import soft_unicode
2022-04-04T18:16:08.380319590Z ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/opt/conda/lib/python3.7/site-packages/markupsafe/__init__.py)
```
This pull request increases the floor on the `jinja2` dependency to >= 3.1 to resolve this issue.

Unrelated: I noticed a small typo in the error handling of the kernelspec cache that has also been addressed.