### PR TITLE
Add doc entry for load-balancing algorithm configuration

### DIFF
--- a/docs/source/operators/config-cli.md
+++ b/docs/source/operators/config-cli.md
@@ -185,6 +185,11 @@ EnterpriseGatewayApp(EnterpriseGatewayConfigMixin, JupyterApp) options
     /api/sessions. (EG_LIST_KERNELS env var) Note: Jupyter Notebook allows this
     by default but Jupyter Enterprise Gateway does not.
     Default: False
+--EnterpriseGatewayApp.load_balancing_algorithm=<Unicode>
+    Specifies which load balancing algorithm DistributedProcessProxy should use.
+    Must be one of "round-robin" or "least-connection".
+    (EG_LOAD_BALANCING_ALGORITHM env var)
+    Default: 'round-robin'
 --EnterpriseGatewayApp.log_datefmt=<Unicode>
     The date format used by logging formatters for %(asctime)s
     Default: '%Y-%m-%d %H:%M:%S'

--- a/docs/source/operators/deploy-distributed.md
+++ b/docs/source/operators/deploy-distributed.md
@@ -75,7 +75,7 @@ _Environment_:
 export EG_LOAD_BALANCING_ALGORITHM=round-robin
 ```
 
-Since _round-robin_ is the defualt load-balancing algorithm, this option is not necessary.
+Since _round-robin_ is the default load-balancing algorithm, this option is not necessary.
 
 ### Least-connection
 

--- a/docs/source/operators/deploy-distributed.md
+++ b/docs/source/operators/deploy-distributed.md
@@ -49,6 +49,60 @@ tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.6.0.tar.gz --strip 1 --direct
 You may find it easier to install all kernel specifications on each node, then remove directories corresponding to specification you're not interested in using.
 ```
 
+## Specifying a load-balancing algorithm
+
+Jupyter Enterprise Gateway provides two ways to configure how kernels are distributed across the configured set of hosts: round-robin or least-connection.
+
+### Round-robin
+
+The round-robin algorithm simply uses an index into the set of configured hosts, incrementing the index on each kernel startup so that it points to the next host in the configured set. To specify the use of round-robin, use one of the following:
+
+_Command-line_:
+
+```bash
+--EnterpriseGatewayApp.load_balancing_algorithm=round-robin
+```
+
+_Configuration_:
+
+```python
+c.EnterpriseGatewayApp.load_balancing_algorithm="round-robin"
+```
+
+_Environment_:
+
+```bash
+export EG_LOAD_BALANCING_ALGORITHM=round-robin
+```
+
+Since _round-robin_ is the defualt load-balancing algorithm, this option is not necessary.
+
+### Least-connection
+
+The least-connection algorithm tracks the hosts that are currently servicing kernels spawned by the Enterprise Gateway instance. Using this information, Enterprise Gateway selects the host with the least number of kernels. It does not consider other information, or whether there is _another_ Enterprise Gateway instance using the same set of hosts. To specify the use of least-connection, use one of the following:
+
+_Command-line_:
+
+```bash
+--EnterpriseGatewayApp.load_balancing_algorithm=least-connection
+```
+
+_Configuration_:
+
+```python
+c.EnterpriseGatewayApp.load_balancing_algorithm="least-connection"
+```
+
+_Environment_:
+
+```bash
+export EG_LOAD_BALANCING_ALGORITHM=least-connection
+```
+
+### Pinning a kernel to a host
+
+A kernel's start request can specify a specific remote host on which to run by specifying that host in the `KERNEL_REMOTE_HOST` environment variable within the request's body. When specified, the configured load-balancing algorithm will be by-passed and the kernel will be started on the specified host.
+
 ## YARN Client Mode
 
 YARN client mode kernel specifications can be considered _distributed mode kernels_. They just happen to use `spark-submit` from different nodes in the cluster but use the `DistributedProcessProxy` to manage their lifecycle.

--- a/docs/source/users/kernel-envs.md
+++ b/docs/source/users/kernel-envs.md
@@ -2,7 +2,7 @@
 
 The Enterprise Gateway client software will also include _any_ environment variables prefixed with `KERNEL_` in the start kernel request sent to the Enterprise Gateway Server. This enables the ability to _statically parameterize_ aspects of kernel start requests relative to other clients using the same Enterprise Gateway instance.
 
-There are several supported `KERNEL_` variables that the Enterprise Gateway server looks for and uses, but others can be sent to customize behaviors. The following kernel-specific environment variables are used by Enterprise Gateway. As mentioned above, all `KERNEL_` variables submitted in the kernel startup request's json body will be available to the kernel for its launch.
+There are several supported `KERNEL_` variables that the Enterprise Gateway server looks for and uses, but others can be sent to customize behaviors. The following kernel-specific environment variables are used by Enterprise Gateway. As mentioned above, all `KERNEL_` variables submitted in the kernel startup request's JSON body will be available to the kernel for its launch.
 
 ```text
   KERNEL_GID=<from user> or 100
@@ -76,6 +76,10 @@ There are several supported `KERNEL_` variables that the Enterprise Gateway serv
     it is the user's responsibility that KERNEL_POD_NAME is unique relative to
     any pods in the target namespace.  In addition, the pod must NOT exist -
     unlike the case if KERNEL_NAMESPACE is provided.
+
+  KERNEL_REMOTE_HOST=<remote host name>
+    DistributedProcessProxy only.  When specified, this value will override the
+    configured load-balancing algorithm.
 
   KERNEL_SERVICE_ACCOUNT_NAME=<from user> or EG_DEFAULT_KERNEL_SERVICE_ACCOUNT_NAME
     Kubernetes only.  This value represents the name of the service account that

--- a/enterprise_gateway/mixins.py
+++ b/enterprise_gateway/mixins.py
@@ -440,7 +440,8 @@ class EnterpriseGatewayConfigMixin(Configurable):
         load_balancing_algorithm_default_value,
         config=True,
         help="""Specifies which load balancing algorithm DistributedProcessProxy should use.
-            Must be one of "round-robin" or "least-connection".
+            Must be one of "round-robin" or "least-connection".  (EG_LOAD_BALANCING_ALGORITHM
+            env var)
             """,
     )
 


### PR DESCRIPTION
This pull request adds the documentation relative to the load-balancing algorithm added as part of #1068.  It essentially adds entries in the Operators Guide in the Command-line options, and Distributed deployments sections.

@LeeMoonCh - I would appreciate your review of this PR.  Thank you.