### PR TITLE
Support startup scripts and ipykernel subclasses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,6 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
-        exclude: etc/kernel-launchers/python/scripts/launch_ipykernel.py
 
   - repo: https://github.com/PyCQA/doc8
     rev: 0.11.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
+        exclude: etc/kernel-launchers/python/scripts/launch_ipykernel.py
 
   - repo: https://github.com/PyCQA/doc8
     rev: 0.11.1

--- a/docs/source/developers/kernel-launcher.md
+++ b/docs/source/developers/kernel-launcher.md
@@ -27,7 +27,49 @@ The payload is then [sent back on a socket](https://github.com/jupyter-server/en
 
 ## Invoking the target kernel
 
-For the Python kernel launcher it merely [embeds](https://github.com/jupyter-server/enterprise_gateway/blob/54c8e31d9b17418f35454b49db691d2ce5643c22/etc/kernel-launchers/python/scripts/launch_ipykernel.py#L382) the kernel using a facility provided by the IPython kernel. For the R kernel launcher, the kernel is started using [`IRKernel::main()`](https://github.com/jupyter-server/enterprise_gateway/blob/54c8e31d9b17418f35454b49db691d2ce5643c22/etc/kernel-launchers/R/scripts/launch_IRkernel.R#L252). The scala kernel launcher works similarly in that the kernel provides an "entrypoint" to start the kernel.
+For the R kernel launcher, the kernel is started using [`IRKernel::main()`](https://github.com/jupyter-server/enterprise_gateway/blob/54c8e31d9b17418f35454b49db691d2ce5643c22/etc/kernel-launchers/R/scripts/launch_IRkernel.R#L252) after the `SparkContext` is initialized based on the `spark-context-initialization-mode` parameter.
+
+The scala kernel launcher works similarly in that the Apache Toree kernel provides an ["entrypoint" to start the kernel](https://github.com/jupyter-server/enterprise_gateway/blob/00d7376b932eacd347b3c32c863691bfbad53b86/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala#L332), however, because the Toree kernel initializes a `SparkContext` itself, the need to do so is conveyed directly to the kernel.
+
+For the Python kernel launcher, it creates a namespace instance that contains the `SparkContext` information, if requested to do so via the `spark-context-initialization-mode` parameter, instantiates an `IPKernelApp` instance using the configured namespace, then calls the [`start()`](https://github.com/ipython/ipykernel/blob/6f448d280dadbff7245f4b28b5e210c899d79342/ipykernel/kernelapp.py#L694) method.
+
+### Invoking subclasses of `ipykernel.kernelbase.Kernel`
+
+Because the python kernel launcher uses `IPKernelApp`, support for any subclass of `ipykernel.kernelbase.Kernel` can be launched by EG's Python kernel launcher.
+
+To specify an alternate subclass, add `--kernel-class-name` (along with the specified dotted class string) to the `kernel.json` file's `argv` stanza. EG's Python launcher will import that class and pass it as a parameter to `IPKernelApp.initialize()`.
+
+Here's an example `kernel.json` file that launches the "echo" kernel using the `DistributedProcessProxy`:
+
+```JSON
+{
+  "display_name": "Echo",
+  "language": "text",
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+    }
+  },
+  "argv": [
+    "python",
+    "/usr/local/share/jupyter/kernels/echo/scripts/launch_ipykernel.py",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}",
+    "--RemoteProcessProxy.public-key",
+    "{public_key}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "none",
+    "--kernel-class-name",
+    "echo_kernel.kernel.EchoKernel"
+  ]
+}
+```
+
+```{admonition} Important!
+The referenced `kernel-class-name` package must first be properly installed on all nodes where the associated process-proxy will run.
+```
 
 ## Listening for interrupt and shutdown requests
 

--- a/docs/source/developers/kernel-specification.md
+++ b/docs/source/developers/kernel-specification.md
@@ -84,4 +84,6 @@ For container-based environments, the `argv` may instead reference a script that
 }
 ```
 
+When using the `launch_ipykernel` launcher (aka the Python kernel launcher), subclasses of `ipykernel.kernelbase.Kernel` can be launched. By default, this launcher uses the classname `"ipykernel.ipkernel.IPythonKernel"`, but other subclasses of `ipykernel.kernelbase.Kernel` can be specified by adding a `--kernel-class-name` parameter to the `argv` stanza. See [Invoking subclasses of `ipykernel.kernelbase.Kernel`](kernel-launcher.md#invoking-subclasses-of-ipykernelkernelbasekernel) for more information.
+
 As should be evident, kernel specifications are highly tuned to the runtime environment so your needs may be different, but _should_ resemble the approaches we've taken so far.

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -14,7 +14,6 @@ from Cryptodome.Cipher import AES, PKCS1_v1_5
 from Cryptodome.PublicKey import RSA
 from Cryptodome.Random import get_random_bytes
 from Cryptodome.Util.Padding import pad
-from future.utils import raise_from
 from jupyter_client.connect import write_connection_file
 
 LAUNCHER_VERSION = 1  # Indicate to server the version of this launcher (payloads may vary)
@@ -149,14 +148,12 @@ class WaitingForSparkSessionToBeInitialized:
             self._init_thread.join(timeout=None)
             exc = self._init_thread.exc
             if exc:
-                raise_from(
-                    RuntimeError(
-                        "Variable: {} was not initialized properly.".format(
-                            self._spark_session_variable
-                        )
-                    ),
-                    exc,
-                )
+                raise RuntimeError(
+                    "Variable: {} was not initialized properly.".format(
+                        self._spark_session_variable
+                    )
+                ) from exc
+
             # now return attribute/function reference from actual Spark object
             return getattr(self._namespace[self._spark_session_variable], name)
 

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -149,9 +149,7 @@ class WaitingForSparkSessionToBeInitialized:
             exc = self._init_thread.exc
             if exc:
                 raise RuntimeError(
-                    "Variable: {} was not initialized properly.".format(
-                        self._spark_session_variable
-                    )
+                    f"Variable: {self._spark_session_variable} was not initialized properly."
                 ) from exc
 
             # now return attribute/function reference from actual Spark object
@@ -172,20 +170,16 @@ def _validate_port_range(port_range):
         if port_range_size != 0:
             if port_range_size < min_port_range_size:
                 raise RuntimeError(
-                    "Port range validation failed for range: '{}'.  Range size must be at least {} as specified by"
-                    " env EG_MIN_PORT_RANGE_SIZE".format(port_range, min_port_range_size)
+                    f"Port range validation failed for range: '{port_range}'.  Range size must be at least "
+                    f"{min_port_range_size} as specified by env EG_MIN_PORT_RANGE_SIZE"
                 )
     except ValueError as ve:
         raise RuntimeError(
-            "Port range validation failed for range: '{port_range}'.  Error was: {ve}".format(
-                port_range=port_range, ve=ve
-            )
+            f"Port range validation failed for range: '{port_range}'.  Error was: {ve}"
         )
     except IndexError as ie:
         raise RuntimeError(
-            "Port range validation failed for range: '{port_range}'.  Error was: {ie}".format(
-                port_range=port_range, ie=ie
-            )
+            f"Port range validation failed for range: '{port_range}'.  Error was: {ie}"
         )
 
     return lower_port, upper_port
@@ -200,7 +194,7 @@ def determine_connection_file(conn_file, kid):
             basename = os.path.splitext(os.path.basename(conn_file))[0]
         fd, conn_file = tempfile.mkstemp(suffix=".json", prefix=basename + "_")
         os.close(fd)
-        logger.debug("Using connection file '{conn_file}'.".format(conn_file=conn_file))
+        logger.debug(f"Using connection file '{conn_file}'.")
 
     return conn_file
 
@@ -243,8 +237,7 @@ def return_connection_info(
     response_parts = response_addr.split(":")
     if len(response_parts) != 2:
         logger.error(
-            "Invalid format for response address '{}'. "
-            "Assuming 'pull' mode...".format(response_addr)
+            f"Invalid format for response address '{response_addr}'. Assuming 'pull' mode..."
         )
         return
 
@@ -253,8 +246,7 @@ def return_connection_info(
         response_port = int(response_parts[1])
     except ValueError:
         logger.error(
-            "Invalid port component found in response address '{}'. "
-            "Assuming 'pull' mode...".format(response_addr)
+            f"Invalid port component found in response address '{response_addr}'. Assuming 'pull' mode..."
         )
         return
 
@@ -276,9 +268,9 @@ def return_connection_info(
     try:
         s.connect((response_ip, response_port))
         json_content = json.dumps(cf_json).encode(encoding="utf-8")
-        logger.debug("JSON Payload '{json_content}".format(json_content=json_content))
+        logger.debug(f"JSON Payload '{json_content}")
         payload = _encrypt(json_content, public_key)
-        logger.debug("Encrypted Payload '{payload}".format(payload=payload))
+        logger.debug(f"Encrypted Payload '{payload}")
         s.send(payload)
     finally:
         s.close()
@@ -293,9 +285,7 @@ def prepare_comm_socket(lower_port, upper_port):
     """
     sock = _select_socket(lower_port, upper_port)
     logger.info(
-        "Signal socket bound to host: {}, port: {}".format(
-            sock.getsockname()[0], sock.getsockname()[1]
-        )
+        f"Signal socket bound to host: {sock.getsockname()[0]}, port: {sock.getsockname()[1]}"
     )
     sock.listen(1)
     sock.settimeout(5)
@@ -334,9 +324,8 @@ def _select_socket(lower_port, upper_port):
             retries = retries + 1
             if retries > max_port_range_retries:
                 raise RuntimeError(
-                    "Failed to locate port within range {}..{} after {} retries!".format(
-                        lower_port, upper_port, max_port_range_retries
-                    )
+                    f"Failed to locate port within range {lower_port}..{upper_port} "
+                    f"after {max_port_range_retries} retries!"
                 )
     return sock
 
@@ -396,7 +385,7 @@ def server_listener(sock, parent_pid):
             if request.get("shutdown") is not None:
                 shutdown = bool(request.get("shutdown"))
             if signum != 0:
-                logger.info("server_listener got request: {request}".format(request=request))
+                logger.info(f"server_listener got request: {request}")
 
 
 def import_item(name):

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -203,7 +203,7 @@ def determine_connection_file(conn_file, kid):
             basename = os.path.splitext(os.path.basename(conn_file))[0]
         fd, conn_file = tempfile.mkstemp(suffix=".json", prefix=basename + "_")
         os.close(fd)
-        logger.debug(f"Using connection file '{conn_file}'.")
+        logger.debug("Using connection file '{conn_file}'.".format(conn_file=conn_file))
 
     return conn_file
 
@@ -279,9 +279,9 @@ def return_connection_info(
     try:
         s.connect((response_ip, response_port))
         json_content = json.dumps(cf_json).encode(encoding="utf-8")
-        logger.debug(f"JSON Payload '{json_content}")
+        logger.debug("JSON Payload '{json_content}".format(json_content=json_content))
         payload = _encrypt(json_content, public_key)
-        logger.debug(f"Encrypted Payload '{payload}")
+        logger.debug("Encrypted Payload '{payload}".format(payload=payload))
         s.send(payload)
     finally:
         s.close()
@@ -399,7 +399,7 @@ def server_listener(sock, parent_pid):
             if request.get("shutdown") is not None:
                 shutdown = bool(request.get("shutdown"))
             if signum != 0:
-                logger.info(f"server_listener got request: {request}")
+                logger.info("server_listener got request: {request}".format(request=request))
 
 
 def import_item(name):


### PR DESCRIPTION
Issues #795 and #1060 both warranted the need to not use `embed_kernel()` when starting a python-based kernel.  `embed_kernel()` was the original approach used to launch the `ipykernel` from our launcher, since we wanted to control the SparkContext variables, but it turns out (at least in my initial testing) that that was not necessary.

This change uses the inspiration from the respective issues (and their authors @lazywhite and @jaybubs, respectively) to address both the startup script issue from #1060 as well as add support for ipykernel derivations like `MatlabKernel` in #795.

We also should try to support older python versions in the launcher, so I reverted the use of `f-strings` for now (as my YARN systems are using older versions of Python).

I installed a startup profile on my test environments with a simple `x = 42` statement and found that after the kernel started that variable and value were immediately available, for both Spark and non-Spark kernels.  @jaybubs, I'm hoping you can take this `launch_ipykernel.py` file for a spin in your environment to check things out.

Regarding support for ipykernel derivations, support for a `--kernel-class-name` option has been provided.  Its default value is `"ipykernel.ipkernel.IPythonKernel"` so that even the default case uses the same machinery.  @lazywhite, I'm hoping you can take  this `launch_ipykernel.py` file for a spin in your environment and, rather than set `--kernel=matlab`, instead use `--kernel-class-name=matlab_kernel.kernel.MatlabKernel`.  This approach avoids having to bake in a list of kernel name to class mappings, etc.

I found it was necessary to pass the `namespace` parameter into the `instance()` method, otherwise, https://github.com/jupyter-server/enterprise_gateway/issues/687 resurfaced.  So please check for this kind of thing using the following...
``` python
a = 123

def fun():
    print(a)
    
fun()
```

Resolves: #795, #1060