### PR TITLE
Remove conda env config from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,33 +32,26 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install ".[test]"
-      - name: Build Jupyter Enterprise Gateway conda env
-        run: |
-          SA="source $CONDA_HOME/bin/activate" make env
       - name: Build and install Jupyter Enterprise Gateway
         uses: nick-invision/retry@v1.0.0
         with:
           timeout_minutes: 10
           max_attempts: 2
           command: |
-            SA="source $CONDA_HOME/bin/activate" make clean dist enterprise-gateway-demo
-            python -m pip install --upgrade dist/*.whl
+            make clean dist enterprise-gateway-demo test-install-wheel
       - name: Log current Python dependencies version
         run: |
           pip freeze
-      - name: Log current Enterprise Gateway version
-        run: |
-          jupyter enterprisegateway --help
-      - name: Run tests
+      - name: Run unit tests
         uses: nick-invision/retry@v1.0.0
         with:
           timeout_minutes: 3
           max_attempts: 1
           command: |
-            pytest -vv
+            make test
       - name: Run integration tests
         run: |
-          SA="source $CONDA_HOME/bin/activate" make itest-yarn
+          make itest-yarn
       - name: Collect logs
         run: |
           python --version
@@ -101,5 +94,4 @@ jobs:
       - name: Build Docs
         run: |
           cd docs
-          pip install -r doc-requirements.txt
-          make html SPHINXOPTS="-W"
+          make requirements html SPHINXOPTS="-W"

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@
     push-kernel-images push-enterprise-gateway push-kernel-py push-kernel-spark-py push-kernel-r push-kernel-spark-r \
     push-kernel-scala push-kernel-tf-py push-kernel-tf-gpu-py push-kernel-image-puller publish helm-chart
 
-SA?=source activate
-ENV:=enterprise-gateway-dev
 SHELL:=/bin/bash
 
 VERSION?=3.0.0.dev0
@@ -32,14 +30,6 @@ help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build:
-env: ## Make a dev environment
-	-conda env create --file requirements.yml --name $(ENV)
-	-conda env config vars set PYTHONPATH=$(PWD) --name $(ENV)
-
-activate: ## Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
-	@echo "Run \`$(SA) $(ENV)\` to activate the environment."
-
 clean: ## Make a clean source tree
 	-rm -rf dist
 	-rm -rf build
@@ -50,50 +40,43 @@ clean: ## Make a clean source tree
 	-find website -name '.sass-cache' -type d -exec rm -fr {} +
 	-find website -name '_site' -type d -exec rm -fr {} +
 	-find website -name 'build' -type d -exec rm -fr {} +
-	-$(SA) $(ENV) && make -C docs clean
-	-$(SA) $(ENV) && make -C etc clean
+	-make -C docs clean
+	-make -C etc clean
 
 lint: ## Check code style
-	$(SA) $(ENV) && pre-commit run --all-files
+	pre-commit run --all-files
 
-nuke: ## Make clean + remove conda env
-	-conda env remove -n $(ENV) -y
-
-dev: ## Make a server in jupyter_websocket mode
-	$(SA) $(ENV) && python enterprise_gateway
+run-dev: test-install-wheel ## Make a server in jupyter_websocket mode
+	python enterprise_gateway
 
 docs: ## Make HTML documentation
-	$(SA) $(ENV) && make -C docs requirements html
+	make -C docs requirements html
 
 kernelspecs:  kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker kernel_image_files ## Create archives with sample kernelspecs
 kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker kernel_image_files:
 	make VERSION=$(VERSION) TAG=$(TAG) SPARK_VERSION=$(SPARK_VERSION) -C  etc $@
 
-install: ## Make a conda env with dist/jupyter_enterprise_gateway-*.whl and dist/jupyter_enterprise_gateway-*.tar.gz installed
-	-conda env remove -y -n $(ENV)-install
-	conda create -y -n $(ENV)-install python=3 pip
-	$(SA) $(ENV)-install && \
-		pip install dist/jupyter_enterprise_gateway-*.whl && \
-			jupyter enterprisegateway --help && \
-			pip uninstall -y jupyter_enterprise_gateway
-	conda env remove -y -n $(ENV)-install
+test-install: test-install-wheel test-install-tar ## Install and minimally run EG with the wheel and tar distributions
 
-	conda create -y -n $(ENV)-install python=3 pip
-	$(SA) $(ENV)-install && \
-		pip install dist/jupyter_enterprise_gateway-*.tar.gz && \
-			jupyter enterprisegateway --help && \
-			pip uninstall -y jupyter_enterprise_gateway
-	conda env remove -y -n $(ENV)-install
+test-install-wheel:
+	pip uninstall -y jupyter_enterprise_gateway
+	pip install dist/jupyter_enterprise_gateway-*.whl && \
+		jupyter enterprisegateway --help
+
+test-install-tar:
+	pip uninstall -y jupyter_enterprise_gateway
+	pip install dist/jupyter_enterprise_gateway-*.tar.gz && \
+		jupyter enterprisegateway --help
 
 bdist: lint
 	make $(WHEEL_FILE)
 
 $(WHEEL_FILE): $(WHEEL_FILES)
-	$(SA) $(ENV) && python setup.py bdist_wheel $(POST_SDIST) \
+	python setup.py bdist_wheel $(POST_SDIST) \
 		&& rm -rf *.egg-info
 
 sdist:
-	$(SA) $(ENV) && python setup.py sdist $(POST_SDIST) \
+	python setup.py sdist $(POST_SDIST) \
 		&& rm -rf *.egg-info
 
 helm-chart: ## Make helm chart distribution
@@ -112,10 +95,10 @@ test-debug:
 test: TEST?=
 test: ## Run unit tests
 ifeq ($(TEST),)
-	$(SA) $(ENV) && pytest -vv $(TEST_DEBUG_OPTS)
+	pytest -vv $(TEST_DEBUG_OPTS)
 else
 # e.g., make test TEST="test_gatewayapp.TestGatewayAppConfig"
-	$(SA) $(ENV) && pytest -vv $(TEST_DEBUG_OPTS) enterprise_gateway/tests/$(TEST)
+	pytest -vv $(TEST_DEBUG_OPTS) enterprise_gateway/tests/$(TEST)
 endif
 
 release: POST_SDIST=upload
@@ -188,7 +171,7 @@ itest-yarn: ## Run integration tests (optionally) against docker demo (YARN) con
 ifeq (1, $(PREP_ITEST_YARN))
 	make itest-yarn-prep
 endif
-	($(SA) $(ENV) && GATEWAY_HOST=$(ITEST_YARN_HOST) LOG_LEVEL=$(LOG_LEVEL) KERNEL_USERNAME=$(ITEST_USER) KERNEL_LAUNCH_TIMEOUT=$(ITEST_KERNEL_LAUNCH_TIMEOUT) SPARK_VERSION=$(SPARK_VERSION) ITEST_HOSTNAME_PREFIX=$(ITEST_HOSTNAME_PREFIX) pytest -vv $(TEST_DEBUG_OPTS) $(ITEST_YARN_TESTS))
+	(GATEWAY_HOST=$(ITEST_YARN_HOST) LOG_LEVEL=$(LOG_LEVEL) KERNEL_USERNAME=$(ITEST_USER) KERNEL_LAUNCH_TIMEOUT=$(ITEST_KERNEL_LAUNCH_TIMEOUT) SPARK_VERSION=$(SPARK_VERSION) ITEST_HOSTNAME_PREFIX=$(ITEST_HOSTNAME_PREFIX) pytest -vv $(TEST_DEBUG_OPTS) $(ITEST_YARN_TESTS))
 	@echo "Run \`docker logs itest-yarn\` to see enterprise-gateway log."
 
 PREP_TIMEOUT?=60
@@ -213,7 +196,7 @@ itest-docker: ## Run integration tests (optionally) against docker swarm
 ifeq (1, $(PREP_ITEST_DOCKER))
 	make itest-docker-prep
 endif
-	($(SA) $(ENV) && GATEWAY_HOST=$(ITEST_DOCKER_HOST) LOG_LEVEL=$(LOG_LEVEL) KERNEL_USERNAME=$(ITEST_USER) KERNEL_LAUNCH_TIMEOUT=$(ITEST_KERNEL_LAUNCH_TIMEOUT) $(ITEST_DOCKER_KERNELS) ITEST_HOSTNAME_PREFIX=$(ITEST_USER) pytest -vv $(TEST_DEBUG_OPTS) $(ITEST_DOCKER_TESTS))
+	(GATEWAY_HOST=$(ITEST_DOCKER_HOST) LOG_LEVEL=$(LOG_LEVEL) KERNEL_USERNAME=$(ITEST_USER) KERNEL_LAUNCH_TIMEOUT=$(ITEST_KERNEL_LAUNCH_TIMEOUT) $(ITEST_DOCKER_KERNELS) ITEST_HOSTNAME_PREFIX=$(ITEST_USER) pytest -vv $(TEST_DEBUG_OPTS) $(ITEST_DOCKER_TESTS))
 	@echo "Run \`docker service logs itest-docker\` to see enterprise-gateway log."
 
 PREP_TIMEOUT?=180

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,11 +7,6 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
 
-# User-friendly check for sphinx-build
-ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/)
-endif
-
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -6,7 +6,7 @@ running tests, building docs, packaging kernel specifications, etc.
 
 ## Prerequisites
 
-Install [miniconda](https://conda.io/miniconda.html) and [GNU make](https://www.gnu.org/software/make/) on your system.
+Install [GNU make](https://www.gnu.org/software/make/) on your system.
 
 ## Clone the repo
 
@@ -28,17 +28,13 @@ Enterprise Gateway's build environment is centered around `make` and the corresp
 Entering `make` with no parameters yields the following:
 
 ```
-activate                       Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
 clean-images                   Remove docker images (includes kernel-based images)
 clean-kernel-images            Remove kernel-based images
 clean                          Make a clean source tree
-dev                            Make a server in jupyter_websocket mode
 dist                           Make source, binary, kernelspecs and helm chart distributions to dist folder
 docker-images                  Build docker images (includes kernel-based images)
 docs                           Make HTML documentation
-env                            Make a dev environment
 helm-chart                     Make helm chart distribution
-install                        Make a conda env with dist/jupyter_enterprise_gateway-*.whl and dist/jupyter_enterprise_gateway-*.tar.gz installed
 itest-docker-debug             Run integration tests (optionally) against docker container with print statements
 itest-docker                   Run integration tests (optionally) against docker swarm
 itest-yarn-debug               Run integration tests (optionally) against docker demo (YARN) container with print statements
@@ -46,34 +42,13 @@ itest-yarn                     Run integration tests (optionally) against docker
 kernel-images                  Build kernel-based docker images
 kernelspecs                    Create archives with sample kernelspecs
 lint                           Check code style
-nuke                           Make clean + remove conda env
 release                        Make a wheel + source release on PyPI
+run-dev                        Make a server in jupyter_websocket mode
+test-install                   Install and minimally run EG with the wheel and tar distributions
 test                           Run unit tests
 ```
 
 Some of the more useful commands are listed below.
-
-## Build the conda environment
-
-Build a Python 3 conda environment containing the necessary dependencies for
-running the enterprise gateway server, running tests, and building documentation.
-
-```bash
-make env
-```
-
-By default, the env built will be named `enterprise-gateway-dev`. To produce a different conda env,
-you can specify the name via the `ENV=` parameter.
-
-```bash
-make ENV=my-conda-env env
-```
-
-```{admonition} Important!
-:class: warning
-If using a non-default conda env, all `make` commands should include the `ENV=` parameter,
-otherwise the command will use the default environment.
-```
 
 ## Build the wheel file
 
@@ -114,7 +89,7 @@ make dist
 Run an instance of the Enterprise Gateway server.
 
 ```bash
-make dev
+make run-dev
 ```
 
 Then access the running server at the URL printed in the console.

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ A lightweight, multi-tenant, scalable and secure gateway that enables
 Jupyter Notebooks to share resources across distributed clusters such as
 Apache Spark, Kubernetes and others..
 """,
+    long_description_content_type="text/plain",
     version=version_ns["__version__"],
     license="BSD",
     platforms="Linux, Mac OS X, Windows",


### PR DESCRIPTION
This pull request removes the use of a conda env from the EG build workflow (primarily in the Makefile).  This simplifies the working environment and appears to trim 3 minutes from each of the python-versioned CI jobs.

While doing this, I found that the former `make install` target was more like a test-install target, so I named it as such and split the two forms of installation it was performing into separate targets (so we can make use of one from our CI actions).

I also noticed that `make dev` was merely running whatever EG was installed, so I updated the target name to `run-dev` and had it depend on an actual build of EG to make it more inclusive.

The docs `Makefile` was also updated because the check for `sphinx-build` was interfering with the ability to install requirements using `make requirements`, which is part of the parent makefile's `make docs` target.

The other changes are mostly to remove the `$(SA) $(ENV)` references that activated the conda env and update the dev workflow docs to not depend on or reference `conda`.

Resolves: #1078