### PR TITLE
Ignore deprecation warning from paramiko during pytest execution

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -33,6 +33,7 @@ from socket import (
     timeout,
 )
 
+import paramiko
 import pexpect
 from Cryptodome.Cipher import AES, PKCS1_v1_5
 from Cryptodome.PublicKey import RSA
@@ -40,8 +41,6 @@ from Cryptodome.Util.Padding import unpad
 from jupyter_client import launch_kernel, localinterfaces
 from jupyter_server import _tz
 from jupyter_server.serverapp import random_ports
-from paramiko.client import AutoAddPolicy, RejectPolicy, SSHClient
-from paramiko.ssh_exception import AuthenticationException, SSHException
 from tornado import web
 from tornado.ioloop import PeriodicCallback
 from traitlets.config import SingletonConfigurable
@@ -660,15 +659,15 @@ class BaseProcessProxyABC(metaclass=abc.ABCMeta):
         ssh = None
 
         try:
-            ssh = SSHClient()
+            ssh = paramiko.SSHClient()
             ssh.load_system_host_keys()
             host_ip = gethostbyname(host)
             if self.use_gss:
                 self.log.debug("Connecting to remote host via GSS.")
-                ssh.set_missing_host_key_policy(AutoAddPolicy())
+                ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
                 ssh.connect(host_ip, port=ssh_port, gss_auth=True)
             else:
-                ssh.set_missing_host_key_policy(RejectPolicy())
+                ssh.set_missing_host_key_policy(paramiko.RejectPolicy())
                 if self.remote_pwd:
                     self.log.debug("Connecting to remote host with username and password.")
                     ssh.connect(
@@ -689,7 +688,7 @@ class BaseProcessProxyABC(metaclass=abc.ABCMeta):
                     type(e).__name__, current_host, host, ssh_port, self.remote_user, e
                 )
             )
-            if e is SSHException or AuthenticationException:
+            if e is paramiko.SSHException or paramiko.AuthenticationException:
                 http_status_code = 403
                 error_message_prefix = "Failed to authenticate SSHClient with password"
                 error_message = error_message_prefix + (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,8 @@ filterwarnings = [
   "error",
   "ignore:There is no current event loop:DeprecationWarning",
   "ignore:Passing unrecognized arguments to super:DeprecationWarning:jupyter_client",
+  # The following needs to remain in place until a new paramiko release is available
+  # that resolves this issue: https://github.com/paramiko/paramiko/issues/2038
+  # Otherwise, pytest execution fails when the deprecation warning is encountered.
+  "ignore:Blowfish has been deprecated:cryptography.utils.CryptographyDeprecationWarning"
 ]


### PR DESCRIPTION
The [paramiko](https://github.com/paramiko/paramiko) package uses the [cyrptography]() package that, as of a couple of days ago, has released a new major version (37.0.0).  This version removes the `blowfish` cipher algorithm.  However, since `paramiko` maintains a static list of algorithms and that list includes `blowfish`, a `cryptography.utils.CryptographyDeprecationWarning: Blowfish has been deprecated` warning message is produced when loading the `paramiko` library.

Because `pytest` treats deprecation warnings as errors (not sure if this is by default or what), the unit tests fail...
```
ERROR enterprise_gateway/tests/test_enterprise_gateway.py - cryptography.utils.CryptographyDeprecationWarning: Blowfish has been deprecated
ERROR enterprise_gateway/tests/test_enterprise_gateway.py - cryptography.utils.CryptographyDeprecationWarning: Blowfish has been deprecated
ERROR enterprise_gateway/tests/test_gatewayapp.py - cryptography.utils.CryptographyDeprecationWarning: Blowfish has been deprecated
ERROR enterprise_gateway/tests/test_gatewayapp.py - cryptography.utils.CryptographyDeprecationWarning: Blowfish has been deprecated
ERROR enterprise_gateway/tests/test_handlers.py - cryptography.utils.CryptographyDeprecationWarning: Blowfish has been deprecated
ERROR enterprise_gateway/tests/test_handlers.py - cryptography.utils.CryptographyDeprecationWarning: Blowfish has been deprecated
```
while general execution of EG simply produces the expected warning...
```
$ jupyter enterprisegateway
/opt/conda/envs/enterprise-gateway-dev/lib/python3.9/site-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
[I 2022-04-27 10:08:20.356 EnterpriseGatewayApp] Jupyter Enterprise Gateway 3.0.0.dev0 is available at http://127.0.0.1:8888
```

This pull request **temporarily** ignores this particular deprecation warning in pytests until the referenced issue in the paramiko repository is resolved.

I felt this was better than temporarily **introducing and capping** a dependency on `cryptography<=37.0`