### PR TITLE
Use hatch and tbump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Bump versions
         run: |
           pip install tbump
-          tbump 100.100.100rc0
+          tbump --dry-run 100.100.100rc0
 
   link_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,10 @@ jobs:
           pip --version
           pip list
           docker logs itest-yarn
+      - name: Bump versions
+        run: |
+          pip install tbump
+          tbump 100.100.100rc0
 
   link_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Bump versions
         run: |
           pip install tbump
-          tbump --dry-run 100.100.100rc0
+          tbump --dry-run --no-tag --no-push 100.100.100rc0
 
   link_check:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling>=0.25"]
+build-backend = "hatchling.build"
 
 [project]
 name = "jupyter_enterprise_gateway"
+version = "3.0.0.dev0"
 description = "A web server for spawning and communicating with remote Jupyter kernels"
 license = { file = "LICENSE.md" }
 keywords = ["Interactive","Interpreter","Kernel", "Web", "Cloud"]
@@ -38,7 +39,6 @@ dependencies = [
   "watchdog>=2.1.3",
   "yarn-api-client>=1.0"
 ]
-dynamic = ["version"]
 
 [[project.authors]]
 name = "Jupyter Development Team"
@@ -61,11 +61,42 @@ test = [
   "websocket-client"
 ]
 
-[tool.flit.module]
-name = "enterprise_gateway"
-
 [project.scripts]
 jupyter-enterprisegateway = "enterprise_gateway.enterprisegatewayapp:launch_instance"
+
+[tool.hatch.build.targets.wheel]
+include = ["enterprise_gateway"]
+
+[tool.tbump.version]
+current = "3.0.0.dev0"
+regex = '''
+  (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+  ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
+'''
+
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"
+
+[[tool.tbump.file]]
+src = "enterprise_gateway/_version.py"
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+
+[[tool.tbump.file]]
+src = "Makefile"
+
+[[tool.tbump.file]]
+src = "etc/kubernetes/helm/enterprise-gateway/Chart.yaml"
+
+[[tool.tbump.field]]
+name = "channel"
+default = ""
+
+[[tool.tbump.field]]
+name = "release"
+default = ""
 
 [tool.jupyter-releaser.options]
 ignore-links = ["http://my-gateway-server.com:8888"]

--- a/release.sh
+++ b/release.sh
@@ -192,11 +192,9 @@ function checkout_code {
 
 function update_version_to_release {
     cd $SOURCE_DIR
-    # Update Python _version.py
-    sed -i .bak "s@^__version__.*@__version__ = '$RELEASE_VERSION'@g" enterprise_gateway/_version.py
 
-    # Update Makefile
-    sed -i .bak "s@$CURRENT_VERSION@$RELEASE_VERSION@g" Makefile
+    pip install tbump
+    tbump $RELEASE_VERSION
 
     # Update Kubernetes deployment descriptor
     sed -i .bak "s@elyra/enterprise-gateway:dev@elyra/enterprise-gateway:$RELEASE_VERSION@g" etc/kubernetes/enterprise-gateway.yaml
@@ -217,11 +215,9 @@ function update_version_to_release {
 
 function update_version_to_development {
     cd $SOURCE_DIR
-    # Update Python _version.py
-    sed -i .bak "s@^__version__.*@__version__ = '$DEVELOPMENT_VERSION'@g" enterprise_gateway/_version.py
 
-    # Update Makefile
-    sed -i .bak "s@$RELEASE_VERSION@$DEVELOPMENT_VERSION@g" Makefile
+    pip install tbump
+    tbump $RELEASE_VERSION
 
     # Update Kubernetes deployment descriptor
     sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/kubernetes/enterprise-gateway.yaml

--- a/release.sh
+++ b/release.sh
@@ -195,7 +195,7 @@ function update_version_to_release {
 
     # Update tbump-managed versions
     pip install tbump
-    tbump --non-interactive $RELEASE_VERSION
+    tbump --non-interactive --no-tag --no-push $RELEASE_VERSION
 
     # Update Kubernetes deployment descriptor
     sed -i .bak "s@elyra/enterprise-gateway:dev@elyra/enterprise-gateway:$RELEASE_VERSION@g" etc/kubernetes/enterprise-gateway.yaml
@@ -219,7 +219,7 @@ function update_version_to_development {
 
     # Update tbump-managed versions
     pip install tbump
-    tbump --non-interactive $RELEASE_VERSION
+    tbump --non-interactive --no-tag --no-push $RELEASE_VERSION
 
     # Update Kubernetes deployment descriptor
     sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/kubernetes/enterprise-gateway.yaml

--- a/release.sh
+++ b/release.sh
@@ -219,7 +219,7 @@ function update_version_to_development {
 
     # Update tbump-managed versions
     pip install tbump
-    tbump --non-interactive --no-tag --no-push $RELEASE_VERSION
+    tbump --non-interactive --no-tag --no-push $DEVELOPMENT_VERSION
 
     # Update Kubernetes deployment descriptor
     sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/kubernetes/enterprise-gateway.yaml

--- a/release.sh
+++ b/release.sh
@@ -193,8 +193,9 @@ function checkout_code {
 function update_version_to_release {
     cd $SOURCE_DIR
 
+    # Update tbump-managed versions
     pip install tbump
-    tbump $RELEASE_VERSION
+    tbump --non-interactive $RELEASE_VERSION
 
     # Update Kubernetes deployment descriptor
     sed -i .bak "s@elyra/enterprise-gateway:dev@elyra/enterprise-gateway:$RELEASE_VERSION@g" etc/kubernetes/enterprise-gateway.yaml
@@ -216,8 +217,9 @@ function update_version_to_release {
 function update_version_to_development {
     cd $SOURCE_DIR
 
+    # Update tbump-managed versions
     pip install tbump
-    tbump $RELEASE_VERSION
+    tbump --non-interactive $RELEASE_VERSION
 
     # Update Kubernetes deployment descriptor
     sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/kubernetes/enterprise-gateway.yaml


### PR DESCRIPTION
Hatch is newly added pypa backend with more flexibility, and helps avoid https://github.com/pypa/pip/issues/11110, which is breaking builds.

Tbump is useful for keeping versions in sync across files.  We use in in Jupyter Releaser.