### PR TITLE
Bump paramiko version, remove temp ignore of deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "jupyter_core>=4.6.0",
   "kubernetes>=4.0.0",
   "jupyter_server>=1.2",
-  "paramiko>=2.1.2",
+  "paramiko>=2.11",
   "pexpect>=4.2.0",
   "pycryptodomex>=3.9.7",
   "pyzmq>=17.0.0",
@@ -111,8 +111,4 @@ filterwarnings = [
   "error",
   "ignore:There is no current event loop:DeprecationWarning",
   "ignore:Passing unrecognized arguments to super:DeprecationWarning:jupyter_client",
-  # The following needs to remain in place until a new paramiko release is available
-  # that resolves this issue: https://github.com/paramiko/paramiko/issues/2038
-  # Otherwise, pytest execution fails when the deprecation warning is encountered.
-  "ignore:Blowfish has been deprecated:cryptography.utils.CryptographyDeprecationWarning"
 ]


### PR DESCRIPTION
Now that an updated release of `paramiko` is available, the [temporary change](https://github.com/jupyter-server/enterprise_gateway/pull/1081) to ignore deprecation warnings due to the removal of `Blowfish` from the `Cryptography` package can now be removed.

This pull request bumps the floor version of `paramiko` to `2.11` and removes the entry to ignore the aforementioned deprecation warning.