### PR TITLE
Use conda clean --all instead of -tipsy

### DIFF
--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -95,7 +95,6 @@ RUN cd /usr/hdp/current && ln -s ./hadoop-$HADOOP_VER hadoop && ln -s ./spark-$S
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -f -b -p $ANACONDA_HOME && \
     rm ~/miniconda.sh && \
-    conda clean -tipsy && \
     rm -rf /home/$NB_USER/.cache/yarn
 
 USER root
@@ -106,7 +105,7 @@ RUN conda install --yes --quiet \
     'r-devtools' \
     'r-stringr' \
     'r-argparse' && \
-    conda clean -tipsy && \
+    conda clean --all && \
     fix-permissions $ANACONDA_HOME && \
     fix-permissions /home/$NB_USER
 

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -14,7 +14,7 @@ RUN conda install --quiet --yes \
     requests \
     future \
     pycryptodomex && \
-    conda clean -tipsy && \
+    conda clean --all && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -11,7 +11,7 @@ RUN conda install --quiet --yes \
     cffi \
     future \
     pycryptodomex && \
-    conda clean -tipsy && \
+    conda clean --all && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -5,7 +5,7 @@ FROM $BASE_CONTAINER
 RUN conda install --quiet --yes \
     'r-argparse' \
     pycryptodomex && \
-    conda clean -tipsy && \
+    conda clean --all && \
     fix-permissions $CONDA_DIR
 
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/


### PR DESCRIPTION
Looks like the `-s` option used in `conda clean` in various Dockerfile scripts has been deprecated and it's recommended that `conda clean --all` be used over `conda clean -tipsy`, so this pull request updates those locations.  We were also calling `conda clean` twice within the demo-base Dockerfile so the first of the two has been removed.

This is part of the release preparation process as this was causing `make docker-images` to fail during the execution of the release script.