### PR TITLE
[Feature] Support for configure magic on Spark Python Kubernetes Kernels (WIP)

### DIFF
--- a/enterprise_gateway/services/kernels/handlers.py
+++ b/enterprise_gateway/services/kernels/handlers.py
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 """Tornado handlers for kernel CRUD and communication."""
+from datetime import datetime, timezone
 import json
 import os
 from functools import partial
@@ -8,7 +9,12 @@ from functools import partial
 import jupyter_server.services.kernels.handlers as jupyter_server_handlers
 import tornado
 from jupyter_client.jsonutil import date_default
+from jupyter_server.base.handlers import APIHandler
 from tornado import web
+try:
+    from jupyter_client.jsonutil import json_default
+except ImportError:
+    from jupyter_client.jsonutil import date_default as json_default
 
 from ...mixins import CORSMixin, JSONErrorsMixin, TokenAuthorizationMixin
 
@@ -146,11 +152,155 @@ class KernelHandler(
         self.finish(json.dumps(model, default=date_default))
 
 
-default_handlers = []
+class ConfigureMagicHandler(CORSMixin, JSONErrorsMixin, APIHandler):
+    @web.authenticated
+    async def post(self, kernel_id):
+        self.log.info(f"Update request received for kernel: {kernel_id}")
+        km = self.kernel_manager
+        km.check_kernel_id(kernel_id)
+        payload = self.get_json_body()
+        self.log.debug(f"Request payload: {payload}")
+        if payload is None:
+            self.log.info("Empty payload in the request body.")
+            self.finish(json.dumps({"message": "Empty payload received. No operation performed on the Kernel."},
+                                   default=date_default))
+            return
+        if type(payload) != dict:
+            self.log.info("Payload is not in acceptable format.")
+            raise web.HTTPError(400, u'Invalid JSON payload received.')
+        if payload.get("env", None) is None:  # We only allow env field for now.
+            self.log.info("Payload is missing the required env field.")
+            raise web.HTTPError(400, u'Missing required field `env` in payload.')
+        kernel = km.get_kernel(kernel_id)
+        if kernel.restarting:  # handle duplicate request.
+            self.log.info("An existing restart request is still in progress. Skipping this request.")
+            raise web.HTTPError(400, u'Duplicate Kernel update request received for Id: %s.' % kernel_id)
+        try:
+            # update Kernel metadata
+            kernel.set_user_extra_overrides(payload)
+            await km.restart_kernel(kernel_id)
+            kernel.fire_kernel_event_callbacks(event="kernel_refresh", zmq_messages=payload.get("zmq_messages", {}))
+        except web.HTTPError as he:
+            self.log.exception(f"HTTPError exception occurred in refreshing kernel: {kernel_id}: {he}")
+            await km.shutdown_kernel(kernel_id)
+            kernel.fire_kernel_event_callbacks(event="kernel_refresh_failure", zmq_messages=payload.get("zmq_messages", {}))
+            raise he
+        except Exception as e:
+            self.log.exception(f"An exception occurred in updating kernel : {kernel_id}: {e}")
+            await km.shutdown_kernel(kernel_id)
+            kernel.fire_kernel_event_callbacks(event="kernel_refresh_failure", zmq_messages=payload.get("zmq_messages", {}))
+            raise web.HTTPError(500, u'Error occurred while refreshing Kernel: %s.' % kernel_id, reason="{}".format(e))
+        else:
+            response_body = {
+                "message": f"Successfully refreshed kernel with id: {kernel_id}"
+            }
+            self.finish(json.dumps(response_body, default=date_default))
+            return
+
+
+class RemoteZMQChannelsHandler(TokenAuthorizationMixin,
+                               CORSMixin,
+                               JSONErrorsMixin,
+                               jupyter_server_handlers.ZMQChannelsHandler):
+
+    def open(self, kernel_id):
+        self.log.info(f"Websocket open request received for kernel: {kernel_id}")
+        super(RemoteZMQChannelsHandler, self).open(kernel_id)
+        km = self.kernel_manager
+        km.add_kernel_event_callbacks(kernel_id, self.on_kernel_refresh, "kernel_refresh")
+        km.add_kernel_event_callbacks(kernel_id, self.on_kernel_refresh_failure, "kernel_refresh_failure")
+
+    def on_kernel_refresh(self, **kwargs):
+        self.log.info("Refreshing the client websocket to kernel connection.")
+        self.refresh_zmq_sockets()
+        zmq_messages = kwargs.get("zmq_messages", {})
+        if "stream_reply" in zmq_messages:
+            self.log.debug("Sending stream_reply success message.")
+            success_message = zmq_messages.get("stream_reply")
+            success_message["content"] = {
+                "name": "stdout",
+                'text': "The Kernel is successfully refreshed."
+            }
+            self._send_ws_message(success_message)
+        if "exec_reply" in zmq_messages:
+            self.log.debug("Sending exec_reply message.")
+            self._send_ws_message(zmq_messages.get("exec_reply"))
+        if "idle_reply" in zmq_messages:
+            self.log.debug("Sending idle_reply message.")
+            self._send_ws_message(zmq_messages.get("idle_reply"))
+        self._send_status_message('kernel_refreshed')  # In the future, UI clients might start to consume this.
+
+    def on_kernel_refresh_failure(self, **kwargs):
+        self.log.error("Kernel %s refresh failed!", self.kernel_id)
+        zmq_messages = kwargs.get("zmq_messages", {})
+        if "error_reply" in zmq_messages:
+            self.log.debug("Sending stream_reply error message.")
+            error_message = zmq_messages.get("error_reply")
+            error_message["content"] = {
+                "ename": "KernelRefreshFailed",
+                'evalue': "The Kernel refresh operation failed.",
+                'traceback': ["The Kernel refresh operation failed."]
+            }
+            self._send_ws_message(error_message)
+        if "exec_reply" in zmq_messages:
+            self.log.debug("Sending exec_reply message.")
+            exec_reply = zmq_messages.get("exec_reply").copy()
+            if "metadata" in exec_reply:
+                exec_reply["metadata"]["status"] = "error"
+            exec_reply["content"]["status"] = "error"
+            exec_reply["content"]["ename"] = "KernelRefreshFailed."
+            exec_reply["content"]["evalue"] = "The Kernel refresh operation failed."
+            exec_reply["content"]["traceback"] = ["The Kernel refresh operation failed."]
+            self._send_ws_message(exec_reply)
+        if "idle_reply" in zmq_messages:
+            self.log.info("Sending idle reply message.")
+            self._send_ws_message(zmq_messages.get("idle_reply"))
+        self.log.debug("sending kernel dead message.")
+        self._send_status_message('dead')
+
+    def refresh_zmq_sockets(self):
+        self.close_existing_streams()
+        kernel = self.kernel_manager.get_kernel(self.kernel_id)
+        self.session.key = kernel.session.key  # refresh the session key
+        self.log.debug("Creating new ZMQ Socket streams.")
+        self.create_stream()
+        for channel, stream in self.channels.items():
+            self.log.debug(f"Updating channel: {channel}")
+            stream.on_recv_stream(self._on_zmq_reply)
+
+    def close_existing_streams(self):
+        self.log.debug(f"Closing existing channels for kernel: {self.kernel_id}")
+        for channel, stream in self.channels.items():
+            if stream is not None and not stream.closed():
+                self.log.debug(f"Close channel : {channel}")
+                stream.on_recv(None)
+                stream.close()
+        self.channels = {}
+
+    def _send_ws_message(self, kernel_msg):
+        self.log.debug(f"Sending websocket message: {kernel_msg}")
+        if "header" in kernel_msg and type(kernel_msg["header"] == dict):
+            kernel_msg["header"]["date"] = datetime.utcnow().replace(tzinfo=timezone.utc)
+        self.write_message(json.dumps(kernel_msg, default=json_default))
+
+    def on_close(self):
+        self.log.info(f"Websocket close request received for kernel: {self.kernel_id}")
+        super(RemoteZMQChannelsHandler, self).on_close()
+        self.kernel_manager.remove_kernel_event_callbacks(self.kernel_id, self.on_kernel_refresh, "kernel_refresh")
+        self.kernel_manager.remove_kernel_event_callbacks(self.kernel_id, self.on_kernel_refresh_failure,
+                                                          "kernel_refresh_failure")
+
+
+_kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
+default_handlers = [
+    (r"/api/configure/%s" % _kernel_id_regex, ConfigureMagicHandler)
+]
 for path, cls in jupyter_server_handlers.default_handlers:
     if cls.__name__ in globals():
         # Use the same named class from here if it exists
         default_handlers.append((path, globals()[cls.__name__]))
+    elif cls.__name__ == jupyter_server_handlers.ZMQChannelsHandler.__name__:  # TODO: check for override.
+        default_handlers.append((path, RemoteZMQChannelsHandler))
     else:
         # Gen a new type with CORS and token auth
         bases = (TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin, cls)

--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -175,6 +175,7 @@ class ContainerProcessProxy(RemoteProcessProxy):
         result = None
 
         if self.container_name:  # We only have something to terminate if we have a name
+            self.log.info(f"Killing Kernel with name: {self.container_name}")
             result = self.terminate_container_resources()
 
         return result

--- a/etc/kernel-launchers/python/scripts/configure_magic.py
+++ b/etc/kernel-launchers/python/scripts/configure_magic.py
@@ -1,0 +1,257 @@
+import base64
+import json
+import logging
+import os
+import sys
+import time
+
+import requests
+from IPython.core.magic import Magics, magics_class, cell_magic
+from json import JSONDecodeError
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+logger = logging.getLogger(__name__)
+logger.name = "configure_magic"
+logger.setLevel(logging.DEBUG)
+logger.propagate = True
+
+RESERVED_SPARK_CONFIGS = [
+    "spark.kubernetes.container.image",
+    "spark.kubernetes.driver.container.image",
+    "spark.kubernetes.executor.container.image",
+    "spark.kubernetes.namespace",
+    "spark.kubernetes.driver.label.component",
+    "spark.kubernetes.executor.label.component"
+    "spark.kubernetes.driver.label.kernel_id",
+    "spark.kubernetes.executor.label.kernel_id",
+    "spark.kubernetes.driver.label.app",
+    "spark.kubernetes.executor.label.app",
+]
+
+
+class InvalidPayloadException(Exception):
+    pass
+
+
+@magics_class
+class ConfigureMagic(Magics):
+    SUPPORTED_MAGIC_FIELDS = {
+        "driverMemory": " --conf spark.driver.memory={} ",
+        "driverCores": " --conf spark.driver.cores={} ",
+        "executorMemory": " --conf spark.executor.memory={} ",
+        "executorCores": " --conf spark.executor.cores={} ",
+        "numExecutors": " --conf spark.executor.instances={} ",
+        "conf": "--conf {}={} ",
+        "launchTimeout": "{}"
+    }
+    MAX_LAUNCH_TIMEOUT = 500
+
+    KERNEL_ID_NOT_FOUND = "We could not find any associated Kernel to apply the magic. Please restart Kernel."
+    EMPTY_INVALID_MAGIC_PAYLOAD = "The magic payload is either empty or not in the correct format." \
+                                  " Please recheck and execute."
+    INVALID_JSON_PAYLOAD = "The magic payload could not be parsed into a valid JSON object. Please recheck and execute."
+    SERVER_ERROR = "An error occurred while updating the kernel configuration: {}."
+    UNKNOWN_ERROR = "An error occurred while processing payload."
+    RESERVED_SPARK_CONFIGS_ERROR = "You are not allowed to override {} spark config as its reserved."
+    MAX_LAUNCH_TIMEOUT_ERROR = "The allowed range for Kernel launchTimeout is (0, {}).".format(MAX_LAUNCH_TIMEOUT)
+    INVALID_PAYLOAD_ERROR = "{} with error: {}"
+
+    def __init__(self, shell=None, **kwargs):
+        logger.info("New Initializing ConfigureMagic...")
+        super().__init__(shell=None, **kwargs)
+        self.shell = shell
+        self.kernel_id = os.environ.get("KERNEL_ID", None)
+        self.endpoint_ip = os.environ.get("ENDPOINT_IP", "").split(":")[0]
+        self.endpoint_port = 9547
+        self.protocol = "https"
+        if self.endpoint_ip == "" or self.endpoint_ip is None:
+            logger.info("Environment var: ENDPOINT_IP not set. Falling back to using localhost.")
+            self.endpoint_ip = "localhost"
+            self.endpoint_port = 18888
+            self.protocol = "http"
+        self.update_kernel_url = "{}://{}:{}/api/configure/{}".format(self.protocol, self.endpoint_ip, self.endpoint_port,
+                                                                    self.kernel_id)
+        logger.debug(f"Kernel Update URL set to: {self.update_kernel_url}")
+        self.headers = {
+            "Content-Type": "application/json",
+        }
+        logger.info("successfully loaded configure magic.")
+
+    @cell_magic
+    def configure(self, line, cell=""):
+        if self.kernel_id is None:
+            logger.error(ConfigureMagic.KERNEL_ID_NOT_FOUND)
+            return ConfigureMagic.KERNEL_ID_NOT_FOUND
+        logger.info(f"Magic cell payload received: {cell}")
+        magic_payload = None
+        try:
+            cell_payload = json.loads(cell)
+            magic_payload = self.convert_to_kernel_update_payload(cell_payload)
+            if not magic_payload:
+                logger.error(f"The payload is either empty or invalid. {magic_payload}")
+                return ConfigureMagic.EMPTY_INVALID_MAGIC_PAYLOAD
+        except ValueError as ve:
+            logger.exception("Could not parse JSON object from input {}: error: {}.".format(cell, ve))
+            return ConfigureMagic.INVALID_JSON_PAYLOAD
+        except JSONDecodeError as jde:
+            logger.exception("Could not parse JSON object from input: {}: error: {}.".format(cell, jde))
+            return ConfigureMagic.INVALID_JSON_PAYLOAD
+        except InvalidPayloadException as ipe:
+            logger.exception(
+                "InvalidPayloadException occurred while processing magic payload: {}: error: {}".format(cell, ipe))
+            return ConfigureMagic.INVALID_PAYLOAD_ERROR.format(InvalidPayloadException.__name__, ipe)
+        except Exception as ex:
+            logger.exception("Exception occurred while processing magic payload: {}: error: {}".format(cell, ex))
+            return ConfigureMagic.UNKNOWN_ERROR
+        else:
+            magic_payload["zmq_messages"] = self.prepare_zmq_messages()
+            logger.debug(f"Payload to refresh: {magic_payload}")
+            result = self.update_kernel(magic_payload)
+            return result
+        return "Done"
+
+    def prepare_zmq_messages(self):
+        messages = {}
+        messages["idle_reply"] = self.prepare_iopub_idle_reply_payload()
+        messages["exec_reply"] = self.prepare_shell_reply_payload()
+        messages["stream_reply"] = self.prepare_iopub_stream_reply_payload()
+        messages["error_reply"] = self.prepare_iopub_error_reply_payload()
+        return messages
+
+    def prepare_iopub_error_reply_payload(self):
+        ipykernel = self.shell.kernel
+        reply_content = {
+            'ename': 'MagicExecutionError',
+            'evalue': 'UnknownError',
+            'traceback': []
+        }
+        parent_headers = self.shell.parent_header["header"].copy()
+        metadata = {}  # ipykernel.init_metadata(parent_headers)
+        error_payload = ipykernel.session.msg(msg_type="error", content=reply_content, parent=parent_headers,
+                                             metadata=metadata)
+        error_payload["channel"] = "iopub"
+        error_payload["buffers"] = []
+        return error_payload
+
+    def prepare_iopub_idle_reply_payload(self):
+        ipykernel = self.shell.kernel
+        reply_content = {
+            'execution_state': 'idle'
+        }
+        parent_headers = self.shell.parent_header["header"].copy()
+        metadata = {}  # ipykernel.init_metadata(parent_headers)
+        idle_payload = ipykernel.session.msg(msg_type="status", content=reply_content, parent=parent_headers,
+                                             metadata=metadata)
+        idle_payload["channel"] = "iopub"
+        idle_payload["buffers"] = []
+        return idle_payload
+
+    def prepare_iopub_stream_reply_payload(self):
+        ipykernel = self.shell.kernel
+        reply_content = {
+            'name': 'stdout',
+            'text': ' '
+        }
+        parent_headers = self.shell.parent_header["header"].copy()
+        metadata = ipykernel.init_metadata(parent_headers)
+        idle_payload = ipykernel.session.msg(msg_type="stream", content=reply_content, parent=parent_headers,
+                                             metadata=metadata)
+        idle_payload["channel"] = "iopub"
+        idle_payload["buffers"] = []
+        return idle_payload
+
+    def prepare_shell_reply_payload(self):
+        ipykernel = self.shell.kernel
+        reply_content = {
+            'status': 'ok',
+            'execution_count': ipykernel.execution_count,
+            'user_expressions': {},
+            'payload': []
+        }
+        parent_headers = self.shell.parent_header["header"].copy()
+        metadata = ipykernel.init_metadata(parent_headers)
+        metadata = ipykernel.finish_metadata(parent_headers, metadata, reply_content)
+        shell_payload = ipykernel.session.msg(msg_type="execute_reply", content=reply_content, parent=parent_headers,
+                                              metadata=metadata)
+        shell_payload["channel"] = "shell"
+        shell_payload["buffers"] = []
+        return shell_payload
+
+    def convert_to_kernel_update_payload(self, cell_payload={}):
+        if not cell_payload or type(cell_payload) != dict:
+            return None
+        magic_payload = {}
+        spark_overrides = ""
+        for magic_key, spark_conf in ConfigureMagic.SUPPORTED_MAGIC_FIELDS.items():
+            magic_prop = cell_payload.get(magic_key, None)
+            if magic_prop is not None:
+                if magic_key == "conf" and type(magic_prop) == dict:
+                    conf_dict = magic_prop
+                    conf = " "
+                    for k, v in conf_dict.items():
+                        if k in RESERVED_SPARK_CONFIGS:
+                            raise InvalidPayloadException(ConfigureMagic.RESERVED_SPARK_CONFIGS_ERROR.format(k))
+                        conf += spark_conf.format(k, v)
+                    spark_overrides += conf
+                elif magic_key == "launchTimeout":
+                    if int(magic_prop) <= 0 or int(magic_prop) > ConfigureMagic.MAX_LAUNCH_TIMEOUT:
+                        raise InvalidPayloadException(ConfigureMagic.MAX_LAUNCH_TIMEOUT_ERROR)
+                    self.populate_env_in_payload(magic_payload, "KERNEL_LAUNCH_TIMEOUT", str(magic_prop))
+                else:
+                    spark_overrides += spark_conf.format(magic_prop)
+        logger.debug(f"KERNEL_EXTRA_SPARK_OPTS: {spark_overrides}")
+        if len(spark_overrides.strip()) != 0:
+            # Do not strip spark_overrides while populating
+            self.populate_env_in_payload(magic_payload, "KERNEL_EXTRA_SPARK_OPTS", spark_overrides)
+        return magic_payload
+
+    def populate_env_in_payload(self, payload, env_key, env_value):
+        if not payload.get('env', None):
+            payload['env'] = {}
+        if env_key and env_value:
+            payload['env'][env_key] = env_value
+        else:
+            logger.error(f"Either key or value is not defined. {env_key}, {env_value}")
+
+    def update_kernel(self, payload_dict):
+        try:
+            logger.info(f"Sending request to update kernel. Please wait while the kernel will be refreshed.")
+            # Flush output before sending the request.
+            sys.stdout.flush()
+            sys.stderr.flush()
+            time.sleep(0.005)  # small delay
+            response = requests.post(self.update_kernel_url, data=json.dumps(payload_dict, default=str),
+                                     headers=self.headers,
+                                     verify=False)
+            response_body = response.json() if response is not None else {}
+            # the below lines are executed only if the request was not successful or runaway kernel case.
+            logger.debug(f"Response received for kernel update: {response.status_code}: body: {response_body}")
+            if response.status_code != 200:
+                error_message = response_body["message"] if response_body.get("message", None) else "Internal Error."
+                logger.error("An error occurred while updating kernel: {}: {}".format(response.status_code,
+                                                                                      error_message))
+                return ConfigureMagic.SERVER_ERROR.format(error_message)
+            else:
+                # if we have hit this, we have a runaway kernel as this pod should have gone down.
+                logger.error("Successfully updated kernel but with possible duplicate / runaway kernel scenario.")
+                return "Status: {}. Possible kernel leak.".format(response)
+        except Exception as ex:
+            logger.exception("Runtime exception occurred: {}", ex)
+            return ConfigureMagic.SERVER_ERROR.format(ex)
+        except KeyboardInterrupt:
+            logger.info("Received Interrupt to shutdown kernel. Please wait while the kernel will be refreshed.")
+
+
+def load_ipython_extension(ipython):
+    # The `ipython` argument is the currently active `InteractiveShell`
+    # instance, which can be used in any way. This allows you to register
+    # new magics or aliases, for example.
+    logger.info("Loading ConfigureMagic ...")
+    ipython.register_magics(ConfigureMagic)
+
+
+def unload_ipython_extension(ipython):
+    logger.info("Unloading ConfigureMagic is a NO-OP. You will need to restart kernel now.")
+    return "NO-OP"


### PR DESCRIPTION
# Feature Description
The changes proposed in this PR are to add support for a well known magic `%%configure -f {}` which allows Notebook users to change the spark properties at runtime without having to create / update any kernel spec file.  This would allow users to change spark driver, executor resources (like cores, memory), enable / disable spark configuration etc. 

**Example**: The below snipped can be copied into a notebook cell to update the various spark properties associated with the current kernel.
```
%%configure -f 
{
  "driverMemory": "3G",
  "driverCores" : "2",
  "executorMemory" : "3G",
  "executorCores" : "2",
  "numExecutors" : 5,
  "conf" : {
      "spark.kubernetes.driver.label.test": "test-label"
  }
}
```

# Implementation Details
The below are the changes made at the high level:

1. I have introduced a new API on JEG `POST api/configure/<kernel_id>` which accepts a payload similar to create kernel API. This API currently support updating the `["KERNEL_EXTRA_SPARK_OPTS", "KERNEL_LAUNCH_TIMEOUT"]` env variables.
2. The above API tries to restart the same Kernel with the updated configuration. This is done because we want to keep the `kernel_id` same and want to give a smooth end user experience.
3. Once the old kernel goes away and a replacement comes up, we also need to refresh the ZMQ sockets to establish the connection with the new kernel so that existing active websocket connection from notebook / jupyterlab UI clients can continue to work. There hooks introduced to handle the same.
4. Further, in order to complete the usual Jupyter Kernel messaging handshake, we fire the missing  zmq messages from JEG to the websocket clients. Example: In order to mark the completion on the current cell, we need to send the `exec_reply` message and to mark the kernel idle, we need to kernel `status=idle` messages etc . These messages are pre-generated on the kernel and sent to JEG while making the API call to refresh the kernel. 

I will update more details about the changes and add some diagrams. 


# Testing
- Basic sanity testing done.  

# Note
Opening this PR for some early feedback and discussion on the changes.
