### PR TITLE
reintroduce conda env setup and docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install ".[test]"
-      - name: Build Jupyter Enterprise Gateway conda env
-        run: |
-          SA="source $CONDA_HOME/bin/activate" make env
       - name: Build and install Jupyter Enterprise Gateway
         uses: nick-invision/retry@v1.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install ".[test]"
+      - name: Build Jupyter Enterprise Gateway conda env
+        run: |
+          SA="source $CONDA_HOME/bin/activate" make env
       - name: Build and install Jupyter Enterprise Gateway
         uses: nick-invision/retry@v1.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@
     push-kernel-images push-enterprise-gateway push-kernel-py push-kernel-spark-py push-kernel-r push-kernel-spark-r \
     push-kernel-scala push-kernel-tf-py push-kernel-tf-gpu-py push-kernel-image-puller publish helm-chart
 
+SA?=source activate
+ENV:=enterprise-gateway-dev
 SHELL:=/bin/bash
 
 VERSION?=3.0.0.dev0
@@ -37,6 +39,14 @@ help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+build:
+env: ## Make a dev environment
+	-conda env create --file requirements.yml --name $(ENV)
+	-conda env config vars set PYTHONPATH=$(PWD) --name $(ENV)
+
+activate: ## Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
+	@echo "Run \`$(SA) $(ENV)\` to activate the environment."
+
 clean: ## Make a clean source tree
 	-rm -rf dist
 	-rm -rf build
@@ -52,6 +62,9 @@ clean: ## Make a clean source tree
 
 lint: ## Check code style
 	pre-commit run --all-files
+
+nuke: ## Make clean + remove conda env
+	-conda env remove -n $(ENV) -y
 
 run-dev: test-install-wheel ## Make a server in jupyter_websocket mode
 	python enterprise_gateway

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-.PHONY: help build clean nuke dev dev-http docs install bdist sdist test release check_dists \
+.PHONY: help build clean remove-env dev dev-http docs install bdist sdist test release check_dists \
     clean-images clean-enterprise-gateway clean-demo-base clean-kernel-images clean-enterprise-gateway \
     clean-kernel-py clean-kernel-spark-py clean-kernel-r clean-kernel-spark-r clean-kernel-scala clean-kernel-tf-py \
     clean-kernel-tf-gpu-py clean-kernel-image-puller push-images push-enterprise-gateway-demo push-demo-base \
@@ -63,7 +63,7 @@ clean: ## Make a clean source tree
 lint: ## Check code style
 	pre-commit run --all-files
 
-nuke: ## Make clean + remove conda env
+remove-env: ## Make clean + remove conda env
 	-conda env remove -n $(ENV) -y
 
 run-dev: test-install-wheel ## Make a server in jupyter_websocket mode

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -44,7 +44,7 @@ itest-yarn                     Run integration tests (optionally) against docker
 kernel-images                  Build kernel-based docker images
 kernelspecs                    Create archives with sample kernelspecs
 lint                           Check code style
-remove-ev                      Make clean + remove conda env
+remove-env                     Make clean + remove conda env
 release                        Make a wheel + source release on PyPI
 run-dev                        Make a server in jupyter_websocket mode
 test-install                   Install and minimally run EG with the wheel and tar distributions

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -28,12 +28,14 @@ Enterprise Gateway's build environment is centered around `make` and the corresp
 Entering `make` with no parameters yields the following:
 
 ```
+ activate                       Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
 clean-images                   Remove docker images (includes kernel-based images)
 clean-kernel-images            Remove kernel-based images
 clean                          Make a clean source tree
 dist                           Make source, binary, kernelspecs and helm chart distributions to dist folder
 docker-images                  Build docker images (includes kernel-based images)
 docs                           Make HTML documentation
+env                            Make a dev environment
 helm-chart                     Make helm chart distribution
 itest-docker-debug             Run integration tests (optionally) against docker container with print statements
 itest-docker                   Run integration tests (optionally) against docker swarm
@@ -42,6 +44,7 @@ itest-yarn                     Run integration tests (optionally) against docker
 kernel-images                  Build kernel-based docker images
 kernelspecs                    Create archives with sample kernelspecs
 lint                           Check code style
+nuke                           Make clean + remove conda env
 release                        Make a wheel + source release on PyPI
 run-dev                        Make a server in jupyter_websocket mode
 test-install                   Install and minimally run EG with the wheel and tar distributions
@@ -49,6 +52,25 @@ test                           Run unit tests
 ```
 
 Some of the more useful commands are listed below.
+
+## Build the conda environment
+
+Build a Python 3 conda environment that can be used to run 
+the Enterprise Gateway server within an IDE. May be necessary prior
+to [debugging Enterprise Gateway](./debug.md) based on your local Python environment.
+See [Conda's Managing environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#managing-environments) 
+for background on environments and why you may find them useful as you develop on Enterprise Gateway.
+
+```bash
+make env
+```
+
+By default, the env built will be named `enterprise-gateway-dev`. To produce a different conda env,
+you can specify the name via the `ENV=` parameter.
+
+```bash
+make ENV=my-conda-env env
+```
 
 ## Build the wheel file
 

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -44,7 +44,7 @@ itest-yarn                     Run integration tests (optionally) against docker
 kernel-images                  Build kernel-based docker images
 kernelspecs                    Create archives with sample kernelspecs
 lint                           Check code style
-nuke                           Make clean + remove conda env
+remove-ev                      Make clean + remove conda env
 release                        Make a wheel + source release on PyPI
 run-dev                        Make a server in jupyter_websocket mode
 test-install                   Install and minimally run EG with the wheel and tar distributions

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -28,7 +28,7 @@ Enterprise Gateway's build environment is centered around `make` and the corresp
 Entering `make` with no parameters yields the following:
 
 ```
- activate                       Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
+activate                       Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
 clean-images                   Remove docker images (includes kernel-based images)
 clean-kernel-images            Remove kernel-based images
 clean                          Make a clean source tree


### PR DESCRIPTION
Per #1098, I am reintroducing some of the conda env pieces to assist with locally running EG and with debugging using an IDE. I specifically brought the targets for making and activating the conda environment but did not add that back to all of the other steps as it remains unnecessary for them. 

I also updated the Contributor docs to reflect the additional step that can be used to aid local development

Resolves: #1098