### PR TITLE
Update dependency requirements to support `make env` target

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,5 +1,3 @@
-# https://github.com/sphinx-doc/sphinx/issues/10291
-jinja2<3.1
 # https://github.com/miyakogi/m2r/issues/66
 mistune<1
 myst-parser

--- a/requirements.yml
+++ b/requirements.yml
@@ -31,5 +31,5 @@ dependencies:
   - flake8
 
   - pip:
-      - ..
+      - .
       - -r docs/doc-requirements.txt

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - docker-py>=3.5.0
   - future
-  - jinja2>=2.10
+  - jinja2>=3.1
   - jupyter_client>=6.1
   - jupyter_core>=4.6.0
   - jupyter_server>=1.2


### PR DESCRIPTION
When attempting to run the newly re-added `make env` target, environment creation was failing citing "`Directory '..' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.`". The directory in `requirements.yml` is updated here (to `.`) to point to the correct location for doc dependency installation.

After this change was made, another error was raised (below) where conda was unable to resolve the project requirement for `jinja2>=3.1` (from `pyproject.toml`) with the doc requirement for `jinja2<3.1`.
```
The conflict is caused by:
    The user requested jinja2<3.1
    jupyter-enterprise-gateway 3.0.0.dev0 depends on jinja2>=3.1
```

The jinja cap in `doc-requirements.txt` (in place due to https://github.com/sphinx-doc/sphinx/issues/10291) is removed here as the cited issue no longer occurs as of `sphinx==4.0.2`. The `make env` target now succeeds.

I also updated the `jinja` dependency to `>=3.1` in `requirements.yml` to bring it in line with the version in  `pyproject.toml` (although I'm not sure if there are reasons for this difference that would make this ill-advised; please advise if so 🙂 ).