### PR TITLE
Typo in make file example for running UTs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ test: ## Run unit tests
 ifeq ($(TEST),)
 	pytest -vv $(TEST_DEBUG_OPTS)
 else
-# e.g., make test TEST="test_gatewayapp.TestGatewayAppConfig"
+# e.g, make test TEST="test_gatewayapp.py::TestGatewayAppConfig"
 	pytest -vv $(TEST_DEBUG_OPTS) enterprise_gateway/tests/$(TEST)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ test: ## Run unit tests
 ifeq ($(TEST),)
 	pytest -vv $(TEST_DEBUG_OPTS)
 else
-# e.g, make test TEST="test_gatewayapp.py::TestGatewayAppConfig"
+# e.g., make test TEST="test_gatewayapp.py::TestGatewayAppConfig"
 	pytest -vv $(TEST_DEBUG_OPTS) enterprise_gateway/tests/$(TEST)
 endif
 

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -112,6 +112,13 @@ Run the unit test suite.
 make test
 ```
 
+To Run a test a subset of tests, we support passing "TEST" argument to the make command as below
+```
+make test TEST="test_gatewayapp.py"
+make test TEST="test_gatewayapp.py::TestGatewayAppConfig
+make test TEST="test_gatewayapp.py::TestGatewayAppConfig::test_config_env_vars_bc"
+```
+
 ## Run the integration tests
 
 Run the integration tests suite.

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -113,6 +113,7 @@ make test
 ```
 
 To Run a test a subset of tests, we support passing "TEST" argument to the make command as below
+
 ```
 make test TEST="test_gatewayapp.py"
 make test TEST="test_gatewayapp.py::TestGatewayAppConfig


### PR DESCRIPTION
# Description 
As per the current example, the syntax shared for running selective UT is: 
`make test TEST="test_gatewayapp::TestGatewayAppConfig" ` which does not work as expected and throws `ERROR: file or directory not found: enterprise_gateway/tests/test_gatewayapp::TestGatewayAppConfig` Exception.

# Step to Reproduce
```
make test TEST="test_gatewayapp::TestGatewayAppConfig"                        
pytest -vv  enterprise_gateway/tests/test_gatewayapp::TestGatewayAppConfig
============================================================== test session starts ==============================================================
platform darwin -- Python 3.8.5, pytest-7.1.2, pluggy-1.0.0 -- /Users/rhgoyal/miniconda3/envs/eg-ut/bin/python3
cachedir: .pytest_cache
rootdir: /Users/rhgoyal/learning/jupyter-project/enterprise_gateway, configfile: pyproject.toml
plugins: anyio-3.6.1, tornasync-0.6.0.post2
collected 0 items                                                                                                                               

============================================================= no tests ran in 0.00s =============================================================
ERROR: file or directory not found: enterprise_gateway/tests/test_gatewayapp::TestGatewayAppConfig

make: *** [test] Error 4

```

# Fix 
- minor typo. 
- doc improvement.