### PR TITLE
Changes for handling interrupts for PySpark Kubernetes Kernel

### DIFF
--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -373,9 +373,9 @@ def cancel_spark_jobs(sig, frame):
             try:
                 __spark_context.cancelAllJobs()
             except Exception as ex:
-                print(f"Error occurred while calling interrupting kernel: {ex}")
+                print(f"Error occurred while interrupting the kernel: {ex}")
         else:
-            print(f"Error occurred  while calling interrupting kernel: {e}")
+            print(f"Error occurred while interrupting the kernel: {e}")
 
 
 def server_listener(sock, parent_pid, cluster_type):

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -369,7 +369,13 @@ def cancel_spark_jobs(sig, frame):
     try:
         __spark_context.cancelAllJobs()
     except Exception as e:
-        print(f"Error occurred while calling handler: {e}")
+        if e.__class__.__name__ == 'Py4JError':
+            try:
+                __spark_context.cancelAllJobs()
+            except Exception as ex:
+                print(f"Error occurred while calling interrupting kernel: {ex}")
+        else:
+            print(f"Error occurred  while calling interrupting kernel: {e}")
 
 
 def server_listener(sock, parent_pid, cluster_type):

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -365,10 +365,10 @@ def get_server_request(sock):
     return request_info
 
 
- def interrupt_handler(sig, frame):
-     try:
-         __spark_context.cancelAllJobs()
-     except Exception as e:
+def interrupt_handler(sig, frame):
+    try:
+        __spark_context.cancelAllJobs()
+    except Exception as e:
         print(f"Error occurred while calling handler{e}")
 
 def server_listener(sock, parent_pid, cluster_type):

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -366,6 +366,8 @@ def get_server_request(sock):
 
 
 def cancel_spark_jobs(sig, frame):
+    if __spark_context is None:
+        return
     try:
         __spark_context.cancelAllJobs()
     except Exception as e:
@@ -373,9 +375,9 @@ def cancel_spark_jobs(sig, frame):
             try:
                 __spark_context.cancelAllJobs()
             except Exception as ex:
-                print(f"Error occurred while interrupting the kernel: {ex}")
+                print(f"Error occurred while re-attempting Spark job cancellation when interrupting the kernel: {ex}")
         else:
-            print(f"Error occurred while interrupting the kernel: {e}")
+            print(f"Error occurred while attempting Spark job cancellation when interrupting the kernel: {e}")
 
 
 def server_listener(sock, parent_pid, cluster_type):

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import random
+import signal
 import socket
 import tempfile
 import uuid
@@ -35,6 +36,7 @@ logger = logging.getLogger("launch_ipykernel")
 logger.setLevel(log_level)
 
 DEFAULT_KERNEL_CLASS_NAME = "ipykernel.ipkernel.IPythonKernel"
+__spark_context = None
 
 
 class ExceptionThread(Thread):
@@ -76,6 +78,9 @@ def initialize_namespace(namespace, cluster_type="spark"):
             """Initialize Spark session and replace global variable
             placeholders with real Spark session object references."""
             spark = SparkSession.builder.getOrCreate()
+
+            global __spark_context
+            __spark_context = spark.sparkContext
 
             # Stop the spark session on exit
             atexit.register(lambda: spark.stop())
@@ -360,7 +365,13 @@ def get_server_request(sock):
     return request_info
 
 
-def server_listener(sock, parent_pid):
+ def interrupt_handler(sig, frame):
+     try:
+         __spark_context.cancelAllJobs()
+     except Exception as e:
+        print(f"Error occurred while calling handler{e}")
+
+def server_listener(sock, parent_pid, cluster_type):
     """Waits for requests from the server and processes each when received.  Currently,
     these will be one of a sending a signal to the corresponding kernel process (signum) or
     stopping the listener and exiting the kernel (shutdown).
@@ -375,6 +386,8 @@ def server_listener(sock, parent_pid):
             if request.get("signum") is not None:
                 signum = int(request.get("signum"))
                 os.kill(parent_pid, signum)
+                if signum == 2 and cluster_type == 'spark':
+                    os.kill(parent_pid, signal.SIGUSR2)
             if request.get("shutdown") is not None:
                 shutdown = bool(request.get("shutdown"))
             if signum != 0:
@@ -582,6 +595,7 @@ if __name__ == "__main__":
                     args=(
                         comm_socket,
                         os.getpid(),
+                        cluster_type,
                     ),
                 )
                 server_listener_process.start()
@@ -589,6 +603,8 @@ if __name__ == "__main__":
     # Initialize the kernel namespace for the given cluster type
     if cluster_type == "spark" and spark_init_mode == "none":
         cluster_type = "none"
+
+    signal.signal(signal.SIGUSR2, interrupt_handler)
 
     # launch the IPython kernel instance
     start_ipython(

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -375,9 +375,13 @@ def cancel_spark_jobs(sig, frame):
             try:
                 __spark_context.cancelAllJobs()
             except Exception as ex:
-                print(f"Error occurred while re-attempting Spark job cancellation when interrupting the kernel: {ex}")
+                print(
+                    f"Error occurred while re-attempting Spark job cancellation when interrupting the kernel: {ex}"
+                )
         else:
-            print(f"Error occurred while attempting Spark job cancellation when interrupting the kernel: {e}")
+            print(
+                f"Error occurred while attempting Spark job cancellation when interrupting the kernel: {e}"
+            )
 
 
 def server_listener(sock, parent_pid, cluster_type):


### PR DESCRIPTION
This PR fixes the issue #1112.
Removed the previous commit and PR(#1114) as we are using the new logic suggested by @kevin-bates.

Testing:
    1. Started a PySpark kernel with the changes.
    2. Started kernels and executed code followed by interrupting the same. Verified job gets killed in Spark Logs and also we can start executing other cells.
    3. Ran jobs in threads and verified all running jobs were killed.