### PR TITLE
Fix shutdown issues

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -1484,22 +1484,19 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
                         if isinstance(e2, OSError) and e2.errno == errno.ENOTCONN:
                             # Listener is not connected.  This is probably a follow-on to ECONNREFUSED on connect
                             self.log.debug(
-                                "ERROR: OSError(ENOTCONN) raised on socket shutdown, "
-                                f"listener likely not connected. Cannot send {request}"
+                                f"OSError(ENOTCONN) raised on socket shutdown, listener "
+                                f"has likely already exited. Cannot send '{request}'"
                             )
                         else:
                             self.log.warning(
-                                "Exception occurred attempting to shutdown communication socket to {}:{} "
-                                "for KernelID '{}' (ignored): {}".format(
-                                    self.comm_ip, self.comm_port, self.kernel_id, str(e2)
-                                )
+                                f"Exception occurred attempting to shutdown communication "
+                                f"socket to {self.comm_ip}:{self.comm_port} "
+                                f"for KernelID '{self.kernel_id}' (ignored): {str(e2)}"
                             )
                 sock.close()
         else:
             self.log.debug(
-                "Invalid comm port, not sending request '{}' to comm_port '{}'.",
-                request,
-                self.comm_port,
+                f"Invalid comm port, not sending request '{request}' to comm_port '{self.comm_port}'."
             )
 
     def send_signal(self, signum):

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -377,7 +377,9 @@ class ResponseManager(SingletonConfigurable):
             self.log.error("No kernel id found in response!  Kernel launch will fail.")
             return
         if kernel_id not in self._response_registry:
-            self.log.error("Kernel id '{}' has not been registered and will not be processed!")
+            self.log.error(
+                f"Kernel id '{kernel_id}' has not been registered and will not be processed!"
+            )
             return
 
         self.log.debug(f"Connection info received for kernel '{kernel_id}': {connection_info}")

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -435,6 +435,15 @@ def start_ipython(
     app.initialize([])
     app.start()
 
+    # cleanup
+    conn_file = kwargs["connection_file"]
+    try:
+        import os  # re-import os since it's removed during namespace manipulation during startup
+
+        os.remove(conn_file)
+    except Exception as e:
+        print(f"Could not delete connection file '{conn_file}' at exit due to error: {e}")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -598,10 +607,3 @@ if __name__ == "__main__":
         ip=ip,
         kernel_class_name=kernel_class_name,
     )
-
-    try:
-        os.remove(connection_file)
-    except Exception as e:
-        logger.warning(
-            f"Could not delete connection file '{connection_file}' at exit due to error: {e}"
-        )

--- a/etc/kernelspecs/spark_R_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_conductor_cluster/kernel.json
@@ -7,7 +7,7 @@
     }
   },
   "env": {
-    "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} ${KERNEL_EXTRA_SPARK_OPTS}",
+    "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.maxAppAttempts=1 ${KERNEL_EXTRA_SPARK_OPTS}",
     "LAUNCH_OPTS": "--customAppName ${KERNEL_ID}"
   },
   "argv": [

--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -8,7 +8,7 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d --conf spark.yarn.appMasterEnv.PATH=/opt/conda/bin:$PATH --conf spark.sparkr.r.command=/opt/conda/lib/R/bin/Rscript ${KERNEL_EXTRA_SPARK_OPTS}",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d --conf spark.yarn.appMasterEnv.PATH=/opt/conda/bin:$PATH --conf spark.sparkr.r.command=/opt/conda/lib/R/bin/Rscript --conf spark.yarn.maxAppAttempts=1 ${KERNEL_EXTRA_SPARK_OPTS}",
     "LAUNCH_OPTS": ""
   },
   "argv": [

--- a/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
@@ -8,7 +8,7 @@
     "debugger": true
   },
   "env": {
-    "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} ${KERNEL_EXTRA_SPARK_OPTS}",
+    "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.maxAppAttempts=1 ${KERNEL_EXTRA_SPARK_OPTS}",
     "LAUNCH_OPTS": ""
   },
   "argv": [

--- a/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
@@ -11,7 +11,7 @@
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "PYSPARK_PYTHON": "/opt/conda/bin/python",
     "PYTHONPATH": "${HOME}/.local/lib/python3.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip",
-    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.appMasterEnv.PYTHONUSERBASE=/home/${KERNEL_USERNAME}/.local --conf spark.yarn.appMasterEnv.PYTHONPATH=${HOME}/.local/lib/python3.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip --conf spark.yarn.appMasterEnv.PATH=/opt/conda/bin:$PATH ${KERNEL_EXTRA_SPARK_OPTS}",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.appMasterEnv.PYTHONUSERBASE=/home/${KERNEL_USERNAME}/.local --conf spark.yarn.appMasterEnv.PYTHONPATH=${HOME}/.local/lib/python3.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip --conf spark.yarn.appMasterEnv.PATH=/opt/conda/bin:$PATH --conf spark.yarn.maxAppAttempts=1 ${KERNEL_EXTRA_SPARK_OPTS}",
     "LAUNCH_OPTS": ""
   },
   "argv": [

--- a/etc/kernelspecs/spark_scala_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_conductor_cluster/kernel.json
@@ -7,7 +7,7 @@
     }
   },
   "env": {
-    "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} ${KERNEL_EXTRA_SPARK_OPTS}",
+    "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.maxAppAttempts=1 ${KERNEL_EXTRA_SPARK_OPTS}",
     "__TOREE_OPTS__": "--alternate-sigint USR2 --spark-context-initialization-mode eager",
     "LAUNCH_OPTS": "",
     "DEFAULT_INTERPRETER": "Scala"

--- a/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
@@ -8,7 +8,7 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "__TOREE_SPARK_OPTS__": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d ${KERNEL_EXTRA_SPARK_OPTS}",
+    "__TOREE_SPARK_OPTS__": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d --conf spark.yarn.maxAppAttempts=1 ${KERNEL_EXTRA_SPARK_OPTS}",
     "__TOREE_OPTS__": "--alternate-sigint USR2",
     "LAUNCH_OPTS": "",
     "DEFAULT_INTERPRETER": "Scala"


### PR DESCRIPTION
While investigating #1116 several issues were identified, primarily relative to interaction with YARN.

1. It was found that an exception was occurring as the Python kernel launcher was terminating.  The suspicion is that this delay lead to the scenario seen in #1116 where, ultimately, the YARN Resource Manager was restarting the launcher while the application was being shut down (and ultimately is shut down).  
2. A similar auto-restart-issue was seen using the Scala kernel but since its launcher wasn't encountering an exception, this was the information needed to conclude that indeed a race condition was occurring between the time the listener/launcher terminates and the time the YARN resource manager shuts down the application (in cluster mode).
3. A couple of the messages surrounding error handling of the listener shutdown had bugs and could be made more clear.


This pull request...
- fixes the launcher's post-kernel clean-up logic, thereby eliminating (probably more like _reducing_) the race condition described in https://github.com/jupyter-server/enterprise_gateway/issues/1116#issuecomment-1159304502.  
- sets the configurable option `--conf spark.yarn.maxAppAttempts=1` to disable the resource manager's auto-restart behavior since Jupyter already has similar logic built into the kernel launch framework (provided by `jupyter_client`'s restarter)
- and fixes issues in the error handling log statements and re-phrases some of the messages to be less urgent.


Resolves #1116