### PR TITLE
Enable EG to create pods via CRDs on Spark Operator

### DIFF
--- a/etc/kubernetes/helm/enterprise-gateway/templates/eg-clusterrole.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/eg-clusterrole.yaml
@@ -20,6 +20,9 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["get", "list", "create", "delete"]
+  - apiGroups: ["sparkoperator.k8s.io"]
+    resources: ["sparkapplications", "sparkapplications/status", "scheduledsparkapplications", "scheduledsparkapplications/status"]
+    verbs: ["get", "watch", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
When integrating EG with Spark Operator, the EG service account
needs to be able to create/schedule "sparkapplications" and thus
require the additional permissions.