### PR TITLE
Make EnterpriseGatewayApp.shutdown more robust, since it's a cleanup procedure

### DIFF
--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -333,7 +333,7 @@ class EnterpriseGatewayApp(EnterpriseGatewayConfigMixin, JupyterApp):
                     self.kernel_manager.shutdown_kernel(kid, now=True)
                 )
             except Exception as ex:
-                self.log.warning("Failed to shut down kernel {}: {}".format(kid, ex))
+                self.log.warning(f"Failed to shut down kernel {kid}: {ex}")
         self.log.info("Shut down complete")
 
     def stop(self):

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -325,11 +325,16 @@ class EnterpriseGatewayApp(EnterpriseGatewayConfigMixin, JupyterApp):
 
     def shutdown(self):
         """Shuts down all running kernels."""
+        self.log.info("Jupyter Enterprise Gateway is shutting down all running kernels")
         kids = self.kernel_manager.list_kernel_ids()
         for kid in kids:
-            asyncio.get_event_loop().run_until_complete(
-                self.kernel_manager.shutdown_kernel(kid, now=True)
-            )
+            try:
+                asyncio.get_event_loop().run_until_complete(
+                    self.kernel_manager.shutdown_kernel(kid, now=True)
+                )
+            except Exception as ex:
+                self.log.warning("Failed to shut down kernel {}: {}".format(kid, ex))
+        self.log.info("Shut down complete")
 
     def stop(self):
         """


### PR DESCRIPTION
In our logs, it happened to get a `raise web.HTTPError(404, u'Kernel does not exist: %s' % kernel_id)` exception in enterprisegatewayapp.shutdown, thus the cleanup being compromised.

Since this function is more a cleanup function, it shouldn't fail and cleanup as much as possible instead. Otherwise, kernels pods may leak.

The "Shut down complete" log is useful to see if termination grace period is enough and EG is not being killed.