### PR TITLE
Update tensorflow-gpu base image

### DIFF
--- a/etc/docker/kernel-tf-gpu-py/Dockerfile
+++ b/etc/docker/kernel-tf-gpu-py/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu:xenial
-ARG BASE_CONTAINER=tensorflow/tensorflow:2.7.0-gpu-jupyter
+ARG BASE_CONTAINER=tensorflow/tensorflow:2.9.1-gpu
 FROM $BASE_CONTAINER
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Attempts to build the tensorflow GPU kernel image using `make kernel-tf-gpu-py` fail with the following:

```
...
#6 4.860 W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
#6 4.860 E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease' is no longer signed.
------
executor failed running [/bin/bash -c apt-get update && apt-get install -yq     build-essential     libsm6     libxext-dev     libxrender1     netcat     python3-dev     tzdata     unzip &&     rm -rf /var/lib/apt/lists/* &&     pip install --upgrade future pycryptodomex ipykernel]: exit code: 100
make[1]: *** [../.image-kernel-tf-gpu-py] Error 1
make: *** [kernel-tf-gpu-py] Error 2
```

This is because the [public key was updated this past April](https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/).  As a result, we need to update the base image for `elyra/kernel-tf-gpu-py` to include a more up-to-date version.  While testing these changes, I also found we don't need to have a Jupyter server baked into the image via the `-jupyter` suffix (which we were using previously).  This saves another 70MB on the image size (although that amount pales in comparison to the overall size).

We're also bumping the Python version from 2.7 to 2.9.