### PR TITLE
Remove references to enterprise-gateway.yaml script

### DIFF
--- a/docs/source/contributors/docker.md
+++ b/docs/source/contributors/docker.md
@@ -8,7 +8,7 @@ The following sections describe the docker images used within Kubernetes and Doc
 
 ## elyra/enterprise-gateway
 
-The primary image for Kubernetes and Docker Swarm support, [elyra/enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) contains the Enterprise Gateway server software and default kernel specifications. For Kubernetes it is deployed using the [enterprise-gateway.yaml](https://github.com/jupyter-server/enterprise_gateway/blob/main/etc/kubernetes/enterprise-gateway.yaml) file or [helm chart](https://github.com/jupyter-server/enterprise_gateway/tree/main/etc/kubernetes/helm/enterprise-gateway). For Docker Swarm, deployment can be accomplished using [docker-componse.yml](https://github.com/jupyter-server/enterprise_gateway/blob/main/etc/docker/docker-compose.yml).
+The primary image for Kubernetes and Docker Swarm support, [elyra/enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) contains the Enterprise Gateway server software and default kernel specifications. For Kubernetes it is deployed using the [helm chart](https://github.com/jupyter-server/enterprise_gateway/tree/main/etc/kubernetes/helm/enterprise-gateway). For Docker Swarm, deployment can be accomplished using [docker-componse.yml](https://github.com/jupyter-server/enterprise_gateway/blob/main/etc/docker/docker-compose.yml).
 
 We recommend that a persistent/mounted volume be used so that the kernel specifications can be accessed outside the container since we've found those to require post-deployment modifications from time to time.
 

--- a/docs/source/contributors/system-architecture.md
+++ b/docs/source/contributors/system-architecture.md
@@ -298,9 +298,7 @@ process proxy configuration to override the global value - enabling finer-graine
 With the popularity of Kubernetes within the enterprise, Enterprise Gateway provides an implementation
 of a process proxy that communicates with the Kubernetes resource manager via the Kubernetes API. Unlike
 the other offerings, in the case of Kubernetes, Enterprise Gateway is itself deployed within the Kubernetes
-cluster as a _Service_ and _Deployment_. The primary vehicle by which this is accomplished is via the
-[enterprise-gateway.yaml](https://github.com/jupyter-server/enterprise_gateway/blob/main/etc/kubernetes/enterprise-gateway.yaml)
-file that contains the necessary metadata to define its deployment. Enterprise Gateway also provides a [helm chart](https://github.com/jupyter-server/enterprise_gateway/tree/main/etc/kubernetes/helm/enterprise-gateway) for those deployments utilizing [Helm](https://helm.sh/).
+cluster as a _Service_ and _Deployment_. The primary vehicle by which this is accomplished is via [Helm](https://helm.sh/) and Enterprise Gateway provides a set of [helm chart](https://github.com/jupyter-server/enterprise_gateway/tree/main/etc/kubernetes/helm/enterprise-gateway) files to simplify deployment.
 
 ```{seealso}
 [Kubernetes deployments](../operators/deploy-kubernetes.md) in the Operators Guide for details.

--- a/docs/source/operators/config-add-env.md
+++ b/docs/source/operators/config-add-env.md
@@ -21,7 +21,7 @@ Besides those environment variables associated with configurable options, the fo
 
   EG_KERNEL_CLUSTER_ROLE=kernel-controller or cluster-admin
     Kubernetes only.  The role to use when binding with the kernel service account.
-    The enterprise-gateway.yaml script creates the cluster role 'kernel-controller'
+    The eg-clusterrole.yaml file creates the cluster role 'kernel-controller'
     and conveys that name via EG_KERNEL_CLUSTER_ROLE.  Should the deployment script
     not set this valuem, Enterprise Gateway will then use 'cluster-admin'.  It is
     recommended this value be set to something other than 'cluster-admin'.
@@ -67,8 +67,8 @@ Besides those environment variables associated with configurable options, the fo
   EG_NAMESPACE=enterprise-gateway or default
     Kubernetes only.  Used during Kubernetes deployment, this indicates the name of
     the namespace in which the Enterprise Gateway service is deployed.  The
-    enterprise-gateway.yaml file creates this namespace, then sets EG_NAMESPACE dring
-    deployment. This value is then used within Enterprise Gateway to coordinate kernel
+    namespace is created prior to deployment, and is set into the EG_NAMESPACE env via
+    deployment.yaml script. This value is then used within Enterprise Gateway to coordinate kernel
     configurations. Should this value not be set during deployment, Enterprise Gateway
     will default its value to namespace 'default'.
 

--- a/etc/docker/enterprise-gateway/README.md
+++ b/etc/docker/enterprise-gateway/README.md
@@ -13,9 +13,7 @@ Pull this image, along with all of the elyra/kernel-\* images to each of your ma
 
 ## Kubernetes
 
-Download the [enterprise-gateway.yaml](https://github.com/jupyter-server/enterprise_gateway/blob/main/etc/kubernetes/enterprise-gateway.yaml) file and make any necessary changes for your configuration. We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
-
-Deploy Jupyter Enterprise Gateway using `kubectl apply -f enterprise-gateway.yaml`
+Enterprise Gateway is deployed into Kubernetes using [Helm](https://helm.sh/). See the [Kubernetes section of our Operator's Guide](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/operators/deploy-kubernetes.html) for further details.
 
 ## Docker Swarm
 


### PR DESCRIPTION
The `check link` CI step is currently failing after we removed `enterprise-gateway.yaml`.  This pull request updates the referenced locations within the documentation and README files.