### PR TITLE
KIP: Define pulled_images as set, not list

### DIFF
--- a/etc/docker/kernel-image-puller/kernel_image_puller.py
+++ b/etc/docker/kernel-image-puller/kernel_image_puller.py
@@ -35,7 +35,7 @@ class KernelImagePuller:
         self.log = kip_logger
         self.worker_queue = None
         self.threads = []
-        self.pulled_images = []
+        self.pulled_images = set()
         self.num_pullers = None
         self.num_retries = None
         self.policy = None
@@ -190,7 +190,7 @@ class KernelImagePuller:
         retries have been exceeded, the queue task is marked as done.
         """
         while True:
-            logger.info("waiting for new imag to pull")
+            logger.debug("Waiting for new image to pull")
             image_name = self.worker_queue.get()
             self.log.info(f"Task received to pull image: {image_name}")
             if image_name is None:


### PR DESCRIPTION
The changes in #1090 inadvertently changed the datatype of `pulled_images` from a `set` to a `list` in the Kernel Image Puller (KIP).  This lead to the following issues for each image pulled (which caused KIP to pull all images on every iteration 3 times):
```
[I 2022-06-29 17:30:17,824 kernel_image_puller.t2] Pulled image 'elyra/kernel-r:kb0' in 1.127 secs.
[W 2022-06-29 17:30:17,824 kernel_image_puller.t2] Attempt 1 to pull image 'elyra/kernel-r:kb0' encountered exception - retrying.  Exception was: 'list' object has no attribute 'add'.
[I 2022-06-29 17:30:17,824 kernel_image_puller.t2] Pulling image 'elyra/kernel-r:kb0'...
[I 2022-06-29 17:30:18,959 kernel_image_puller.t2] Pulled image 'elyra/kernel-r:kb0' in 1.135 secs.
[W 2022-06-29 17:30:18,959 kernel_image_puller.t2] Attempt 2 to pull image 'elyra/kernel-r:kb0' encountered exception - retrying.  Exception was: 'list' object has no attribute 'add'.
[I 2022-06-29 17:30:18,959 kernel_image_puller.t2] Pulling image 'elyra/kernel-r:kb0'...
[I 2022-06-29 17:30:20,134 kernel_image_puller.t2] Pulled image 'elyra/kernel-r:kb0' in 1.174 secs.
[E 2022-06-29 17:30:20,134 kernel_image_puller.t2] Attempt 3 to pull image 'elyra/kernel-r:kb0' failed with exception: 'list' object has no attribute 'add'
[I 2022-06-29 17:30:20,134 kernel_image_puller.t2] waiting for new imag to pull
```
I also addressed the typo in the last log statement and changed it to DEBUG.