### PR TITLE
Switch default to create PSP in KIP to false due to deprecation

### DIFF
--- a/etc/kubernetes/helm/enterprise-gateway/values.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -129,7 +129,11 @@ kip:
     port: 8888
     validate_cert: false
   podSecurityPolicy:
-    create: true
+    # Note: PodSecurityPolicy is deprecated as of 1.21 and removed in 1.25.
+    # Operators deploying into k8s clusters >= 1.25 that require PSP equivalency will need to
+    # look into alternatives like Gatekeeper (https://github.com/open-policy-agent/gatekeeper).
+    # Creation of PSP in KIP is disabled by default.
+    create: false
     annotations: {}
   # Kernel Image Puller image name and tag to use.
   image: elyra/kernel-image-puller:dev


### PR DESCRIPTION
Per the discussion starting [here](https://github.com/jupyter-server/enterprise_gateway/pull/1073#issuecomment-1175329542), we should disable the default to create a `PodSecurityPolicy` in the Kernel Image Puller.  I've also included a comment indicating the applicable versions/timeframe, along with a suggestion for how an operator would need to proceed if using a version of K8s in which PSPs don't exist.

The table of [K8s/Helm options in the Operators Guide](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/operators/deploy-kubernetes.html#helm-configuration-parameters), already show the default as `false`. :+1:

Thanks to @darkstarmv for their helpful information.