### PR TITLE
851: Add typing hints to process proxies

### DIFF
--- a/enterprise_gateway/services/processproxies/conductor.py
+++ b/enterprise_gateway/services/processproxies/conductor.py
@@ -11,10 +11,12 @@ import socket
 import subprocess
 import time
 from random import randint
+from typing import Any, List, Optional, Type
 
 from jupyter_client import localinterfaces
 from jupyter_server.utils import url_unescape
 
+from ..kernels.remotemanager import RemoteKernelManager
 from .processproxy import RemoteProcessProxy
 
 pjoin = os.path.join
@@ -31,7 +33,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
     initial_states = {"SUBMITTED", "WAITING", "RUNNING"}
     final_states = {"FINISHED", "KILLED", "RECLAIMED"}  # Don't include FAILED state
 
-    def __init__(self, kernel_manager, proxy_config):
+    def __init__(self, kernel_manager: RemoteKernelManager, proxy_config: dict):
         super().__init__(kernel_manager, proxy_config)
         self.application_id = None
         self.driver_id = None
@@ -43,7 +45,9 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         )
         self.ascd_endpoint = self.conductor_endpoint
 
-    async def launch_process(self, kernel_cmd, **kwargs):
+    async def launch_process(
+        self, kernel_cmd: str, **kwargs: Optional[dict[str, Any]]
+    ) -> Type["ConductorClusterProcessProxy"]:
         """
         Launches the specified process within a Conductor cluster environment.
         """
@@ -88,7 +92,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         await self.confirm_remote_startup()
         return self
 
-    def _update_launch_info(self, kernel_cmd, env_dict):
+    def _update_launch_info(self, kernel_cmd: List[str], env_dict: dict) -> None:
         """
         Dynamically assemble the spark-submit configuration passed from NB2KG.
         """
@@ -126,7 +130,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
                 )
             )
 
-    def _update_notebook_master_rest_url(self, env_dict):
+    def _update_notebook_master_rest_url(self, env_dict: dict) -> None:
         """
         Updates the notebook master rest url to update KERNEL_NOTEBOOK_MASTER_REST,
         conductor_endpoint, and SPARK_OPTS.
@@ -228,7 +232,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
             env_dict["KERNEL_NOTEBOOK_MASTER_REST"] = updated_one_notebook_master_rest_url
             self.conductor_endpoint = updated_one_notebook_master_web_submission_url
 
-    def poll(self):
+    def poll(self) -> Optional[bool]:
         """
         Submitting a new kernel/app will take a while to be SUBMITTED.
         Thus application ID will probably not be available immediately for poll.
@@ -243,11 +247,11 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
                 result = None
         return result
 
-    def send_signal(self, signum):
+    def send_signal(self, signum: int) -> Optional[bool]:
         """
         Currently only support 0 as poll and other as kill.
         :param signum
-        :return:
+        :return: None if signal was successfully sent to kernel, False if an exception was thrown
         """
         self.log.debug(f"ConductorClusterProcessProxy.send_signal {signum}")
         if signum == 0:
@@ -257,7 +261,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         else:
             return super().send_signal(signum)
 
-    def kill(self):
+    def kill(self) -> Optional[bool]:
         """
         Kill a kernel.
         :return: None if the application existed and is not in RUNNING state, False otherwise.
@@ -289,7 +293,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         )
         return result
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         # we might have a defunct process (if using waitAppCompletion = false) - so poll, kill, wait when we have
         # a local_proc.
         if self.local_proc:
@@ -309,7 +313,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         # for cleanup, we should call the superclass last
         super().cleanup()
 
-    def _parse_driver_submission_id(self, submission_response):
+    def _parse_driver_submission_id(self, submission_response: str) -> None:
         """
         Parse driver id from stderr gotten back from launch_kernel
         :param submission_response
@@ -339,7 +343,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
                     reason=err_lines[0][err_lines[0].find("Application submission failed") :],
                 )
 
-    async def confirm_remote_startup(self):
+    async def confirm_remote_startup(self) -> None:
         """
         Confirms the application is in a started state before returning.  Should post-RUNNING states be
         unexpectedly encountered ('FINISHED', 'KILLED', 'RECLAIMED') then we must throw, otherwise the rest
@@ -380,7 +384,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
             else:
                 self.detect_launch_failure()
 
-    def _get_application_state(self):
+    # confirm return typing
+    def _get_application_state(self) -> str:
         """
         Gets the current application state using the application_id already obtained.  Once the assigned host
         has been identified, it is no longer accessed.
@@ -398,7 +403,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
                     self.assigned_ip = socket.gethostbyname(self.assigned_host)
         return app_state
 
-    async def handle_timeout(self):
+    async def handle_timeout(self) -> None:
         """
         Checks to see if the kernel launch timeout has been exceeded while awaiting connection info.
         """
@@ -431,7 +436,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
             )
             self.log_and_raise(http_status_code=error_http_code, reason=timeout_message)
 
-    def _get_application_id(self, ignore_final_states=False):
+    # confirm return typing
+    def _get_application_id(self, ignore_final_states: bool = False) -> str:
         """
         Return the kernel's application ID if available, otherwise None.  If we're obtaining application_id
         from scratch, do not consider kernels in final states.
@@ -470,7 +476,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
                 )
         return self.application_id
 
-    def get_process_info(self):
+    # confirm return typing
+    def get_process_info(self) -> dict[str, Any]:
         """
         Captures the base information necessary for kernel persistence relative to Conductor clusters.
         """
@@ -479,7 +486,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         process_info.update({"rest_credential": self.rest_credential})
         return process_info
 
-    def load_process_info(self, process_info):
+    def load_process_info(self, process_info: dict[str, Any]) -> None:
         """
         Captures the base information necessary for kernel persistence relative to Conductor clusters.
         """
@@ -487,7 +494,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         self.application_id = process_info["application_id"]
         self.rest_credential = process_info["rest_credential"]
 
-    def _query_app_by_driver_id(self, driver_id):
+    # confirm return typing
+    def _query_app_by_driver_id(self, driver_id: str) -> Optional[List[str]]:
         """
         Retrieve application by using driver ID.
         :param driver_id: as the unique driver id for query
@@ -525,7 +533,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
             )
         return response
 
-    def _query_app_by_id(self, app_id):
+    # confirm return typing
+    def _query_app_by_id(self, app_id: str) -> Optional[List[str]]:
         """
         Retrieve an application by application ID.
         :param app_id
@@ -560,7 +569,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
             )
         return response
 
-    def _query_app_state_by_driver_id(self, driver_id):
+    # confirm return typing
+    def _query_app_state_by_driver_id(self, driver_id: str):
         """
         Return the state of an application.
         :param driver_id:
@@ -574,7 +584,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
                     response = app["state"]
         return response
 
-    def _get_driver_by_app_id(self, app_id):
+    # confirm return typing
+    def _get_driver_by_app_id(self, app_id: str):
         """
         Get driver info from application ID.
         :param app_id
@@ -591,7 +602,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
             self.log.warning("Application id does not exist")
         return response
 
-    def _kill_app_by_driver_id(self, driver_id):
+    def _kill_app_by_driver_id(self, driver_id: str):
         """
         Kill an application. If the app's state is FINISHED or FAILED, it won't be changed to KILLED.
         :param driver_id
@@ -639,7 +650,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         self.log.debug(f"Kill response: {response}")
         return response
 
-    def _performRestCall(self, cmd, url, HA_LIST):
+    def _performRestCall(self, cmd: List[str], url: str, HA_LIST: List[str]) -> tuple:
         for HA in HA_LIST:
             portcolon = url.rfind(":")
             slash = url.find("://")
@@ -665,7 +676,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         )
         return "Error", "Error"
 
-    def _performConductorJWTLogonAndRetrieval(self, jwt_token, env_dict):
+    # confirm return type
+    def _performConductorJWTLogonAndRetrieval(self, jwt_token: str, env_dict: dict[str, Any]):
         """
         Authenticate to Conductor with a JWT Token and setup the kernel environment variables.
         :param jwt_token: JWT Token to authenticate with to Conductor

--- a/enterprise_gateway/services/processproxies/crd.py
+++ b/enterprise_gateway/services/processproxies/crd.py
@@ -1,9 +1,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 """Code related to managing kernels running based on k8s custom resource."""
+from typing import Any, Optional, Type
 
 from kubernetes import client
 
+from ..kernels.remotemanager import RemoteKernelManager
 from .k8s import KubernetesProcessProxy
 
 
@@ -12,10 +14,12 @@ class CustomResourceProcessProxy(KubernetesProcessProxy):
     custom_resource_template_name = None
     kernel_resource_name = None
 
-    def __init__(self, kernel_manager, proxy_config):
+    def __init__(self, kernel_manager: RemoteKernelManager, proxy_config: dict):
         super().__init__(kernel_manager, proxy_config)
 
-    async def launch_process(self, kernel_cmd, **kwargs):
+    async def launch_process(
+        self, kernel_cmd: str, **kwargs: Optional[dict[str, Any]]
+    ) -> Type["CustomResourceProcessProxy"]:
         kwargs["env"][
             "KERNEL_RESOURCE_NAME"
         ] = self.kernel_resource_name = self._determine_kernel_pod_name(**kwargs)
@@ -26,7 +30,7 @@ class CustomResourceProcessProxy(KubernetesProcessProxy):
         await super().launch_process(kernel_cmd, **kwargs)
         return self
 
-    def kill(self):
+    def kill(self) -> Optional[bool]:
         result = None
 
         if self.kernel_resource_name:
@@ -50,7 +54,7 @@ class CustomResourceProcessProxy(KubernetesProcessProxy):
 
         return result
 
-    def terminate_custom_resource(self):
+    def terminate_custom_resource(self) -> bool:
         try:
             delete_status = client.CustomObjectsApi().delete_cluster_custom_object(
                 self.group, self.version, self.plurals, self.kernel_resource_name

--- a/enterprise_gateway/services/processproxies/docker_swarm.py
+++ b/enterprise_gateway/services/processproxies/docker_swarm.py
@@ -4,13 +4,17 @@
 
 import logging
 import os
+from typing import Any, Optional, Set, Type
 
 from docker.client import DockerClient
 from docker.errors import NotFound
-
-from .container import ContainerProcessProxy
+from docker.models.containers import Container
+from docker.models.services import Service
 
 # Debug logging level of docker produces too much noise - raise to info by default.
+from ..kernels.remotemanager import RemoteKernelManager
+from .container import ContainerProcessProxy
+
 logging.getLogger("urllib3.connectionpool").setLevel(
     os.environ.get("EG_DOCKER_LOG_LEVEL", logging.WARNING)
 )
@@ -25,10 +29,12 @@ class DockerSwarmProcessProxy(ContainerProcessProxy):
     Kernel lifecycle management for kernels in Docker Swarm.
     """
 
-    def __init__(self, kernel_manager, proxy_config):
+    def __init__(self, kernel_manager: RemoteKernelManager, proxy_config: dict):
         super().__init__(kernel_manager, proxy_config)
 
-    def launch_process(self, kernel_cmd, **kwargs):
+    def launch_process(
+        self, kernel_cmd: str, **kwargs: Optional[dict[str, Any]]
+    ) -> Type["DockerSwarmProcessProxy"]:
         """
         Launches the specified process within a Docker Swarm environment.
         """
@@ -37,11 +43,11 @@ class DockerSwarmProcessProxy(ContainerProcessProxy):
         kwargs["env"]["EG_DOCKER_MODE"] = "swarm"
         return super().launch_process(kernel_cmd, **kwargs)
 
-    def get_initial_states(self):
+    def get_initial_states(self) -> Set:
         """Return list of states indicating container is starting (includes running)."""
         return {"preparing", "starting", "running"}
 
-    def _get_service(self):
+    def _get_service(self) -> Service:
         # Fetches the service object corresponding to the kernel with a matching label.
         service = None
         services = client.services.list(filters={"label": "kernel_id=" + self.kernel_id})
@@ -58,7 +64,7 @@ class DockerSwarmProcessProxy(ContainerProcessProxy):
             self.container_name = service.name
         return service
 
-    def _get_task(self):
+    def _get_task(self) -> dict:
         # Fetches the task object corresponding to the service associated with the kernel.  We only ask for the
         # current task with desired-state == running.  This eliminates failed states.
 
@@ -78,7 +84,7 @@ class DockerSwarmProcessProxy(ContainerProcessProxy):
                 task = tasks[0]
         return task
 
-    def get_container_status(self, iteration):
+    def get_container_status(self, iteration: Optional[int]) -> str:
         """Return current container state."""
         # Locates the kernel container using the kernel_id filter.  If the status indicates an initial state we
         # should be able to get at the NetworksAttachments and determine the associated container's IP address.
@@ -115,7 +121,7 @@ class DockerSwarmProcessProxy(ContainerProcessProxy):
             )
         return task_state
 
-    def terminate_container_resources(self):
+    def terminate_container_resources(self) -> Optional[bool]:
         """Terminate any artifacts created on behalf of the container's lifetime."""
         # Remove the docker service.
 
@@ -155,21 +161,23 @@ class DockerSwarmProcessProxy(ContainerProcessProxy):
 class DockerProcessProxy(ContainerProcessProxy):
     """Kernel lifecycle management for Docker kernels (non-Swarm)."""
 
-    def __init__(self, kernel_manager, proxy_config):
+    def __init__(self, kernel_manager: RemoteKernelManager, proxy_config: dict):
         super().__init__(kernel_manager, proxy_config)
 
-    def launch_process(self, kernel_cmd, **kwargs):
+    def launch_process(
+        self, kernel_cmd: str, **kwargs: Optional[dict[str, Any]]
+    ) -> Type["DockerProcessProxy"]:
         """Launches the specified process within a Docker environment."""
         # Convey the network to the docker launch script
         kwargs["env"]["EG_DOCKER_NETWORK"] = docker_network
         kwargs["env"]["EG_DOCKER_MODE"] = "docker"
         return super().launch_process(kernel_cmd, **kwargs)
 
-    def get_initial_states(self):
+    def get_initial_states(self) -> Set:
         """Return list of states indicating container is starting (includes running)."""
         return {"created", "running"}
 
-    def _get_container(self):
+    def _get_container(self) -> Container:
         # Fetches the container object corresponding the the kernel_id label.
         # Only used when docker mode == regular (not swarm)
 
@@ -187,7 +195,7 @@ class DockerProcessProxy(ContainerProcessProxy):
             container = containers[0]
         return container
 
-    def get_container_status(self, iteration):
+    def get_container_status(self, iteration: Optional[int]) -> str:
         """Return current container state."""
         # Locates the kernel container using the kernel_id filter.  If the phase indicates Running, the pod's IP
         # is used for the assigned_ip.  Only used when docker mode == regular (non swarm)
@@ -233,7 +241,7 @@ class DockerProcessProxy(ContainerProcessProxy):
 
         return container_status
 
-    def terminate_container_resources(self):
+    def terminate_container_resources(self) -> Optional[bool]:
         """Terminate any artifacts created on behalf of the container's lifetime."""
         # Remove the container
 

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -31,6 +31,7 @@ from socket import (
     socket,
     timeout,
 )
+from typing import Any, Optional, Type
 
 import paramiko
 import pexpect
@@ -45,6 +46,7 @@ from tornado.ioloop import PeriodicCallback
 from traitlets.config import SingletonConfigurable
 from zmq.ssh import tunnel
 
+from ..kernels.remotemanager import RemoteKernelManager
 from ..sessions.kernelsessionmanager import KernelSessionManager
 
 # Default logging level of paramiko produces too much noise - raise to warning only.
@@ -82,7 +84,7 @@ max_keep_alive_interval = 100 * 365 * 24 * 60 * 60
 prohibited_local_ips = os.getenv("EG_PROHIBITED_LOCAL_IPS", "").split(",")
 
 
-def _get_local_ip():
+def _get_local_ip() -> str:
     """
     Honor the prohibited IPs, locating the first not in the list.
     """
@@ -154,7 +156,7 @@ class ResponseManager(SingletonConfigurable):
     KEY_SIZE = 1024  # Can be small since it's only used to {en,de}crypt the AES key.
     _instance = None
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Optional[dict[str, Any]]):
         super().__init__(**kwargs)
         self._response_ip = None
         self._response_port = None
@@ -195,7 +197,7 @@ class ResponseManager(SingletonConfigurable):
         await asyncio.wait_for(self._response_registry[kernel_id].wait(), connection_interval)
         return self._response_registry.pop(kernel_id).response
 
-    def _prepare_response_socket(self):
+    def _prepare_response_socket(self) -> None:
         """Prepares the response socket on which connection info arrives from remote kernel launcher."""
         s = socket(AF_INET, SOCK_STREAM)
         s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
@@ -284,7 +286,7 @@ class ResponseManager(SingletonConfigurable):
         except Exception as ex:
             self.log.error(f"Failure occurred processing connection: {ex}")
 
-    def _decode_payload(self, data) -> dict:
+    def _decode_payload(self, data: json) -> dict:
         """
         Decodes the payload.
 
@@ -1023,11 +1025,13 @@ class LocalProcessProxy(BaseProcessProxyABC):
     This process proxy is used when no other process proxy is configured.
     """
 
-    def __init__(self, kernel_manager, proxy_config):
+    def __init__(self, kernel_manager: RemoteKernelManager, proxy_config: dict):
         super().__init__(kernel_manager, proxy_config)
         kernel_manager.ip = localinterfaces.LOCALHOST
 
-    async def launch_process(self, kernel_cmd, **kwargs):
+    async def launch_process(
+        self, kernel_cmd: str, **kwargs: Optional[dict[str, Any]]
+    ) -> Type["LocalProcessProxy"]:
         await super().launch_process(kernel_cmd, **kwargs)
 
         # launch the local run.sh
@@ -1087,7 +1091,7 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
         """Confirms the remote process has started and returned necessary connection information."""
         pass
 
-    def detect_launch_failure(self):
+    def detect_launch_failure(self) -> None:
         """
         Helper method called from implementations of `confirm_remote_startup()` that checks if
         self.local_proc (a popen instance) has terminated prior to the confirmation of startup.
@@ -1114,7 +1118,9 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
                 self.local_proc = None
                 self.log_and_raise(http_status_code=500, reason=error_message)
 
-    def _tunnel_to_kernel(self, connection_info, server, port=ssh_port, key=None):
+    def _tunnel_to_kernel(
+        self, connection_info: dict, server: str, port: int = ssh_port, key: str = None
+    ) -> tuple:
         """
         Tunnel connections to a kernel over SSH
 
@@ -1157,8 +1163,14 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
         return tuple(lports)
 
     def _tunnel_to_port(
-        self, kernel_channel, remote_ip, remote_port, server, port=ssh_port, key=None
-    ):
+        self,
+        kernel_channel: KernelChannel,
+        remote_ip: str,
+        remote_port: int,
+        server: str,
+        port: int = ssh_port,
+        key: str = None,
+    ) -> int:
         """
         Analogous to _tunnel_to_kernel, but deals with a single port.  This will typically be called for
         any one-off ports that require tunnelling. Note - this method assumes that passwordless ssh is
@@ -1171,8 +1183,15 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
         return local_port
 
     def _create_ssh_tunnel(
-        self, kernel_channel, local_port, remote_port, remote_ip, server, port, key
-    ):
+        self,
+        kernel_channel: KernelChannel,
+        local_port: int,
+        remote_port: int,
+        remote_ip: str,
+        server: str,
+        port: int,
+        key: str,
+    ) -> None:
         """
         Creates an SSH tunnel between the local and remote port/server for the given kernel channel.
         """
@@ -1196,7 +1215,14 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
             )
 
     def _spawn_ssh_tunnel(
-        self, kernel_channel, local_port, remote_port, remote_ip, server, port=ssh_port, key=None
+        self,
+        kernel_channel: KernelChannel,
+        local_port: int,
+        remote_port: int,
+        remote_ip: str,
+        server: str,
+        port: int = ssh_port,
+        key: Optional[str] = None,
     ):
         """
         This method spawns a child process to create an SSH tunnel and returns the spawned process.
@@ -1231,7 +1257,7 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
             )
             return pexpect.spawn(cmd, env=os.environ.copy().pop("SSH_ASKPASS", None))
 
-    def _get_keep_alive_interval(self, kernel_channel):
+    def _get_keep_alive_interval(self, kernel_channel: KernelChannel) -> int:
         cull_idle_timeout = self.kernel_manager.cull_idle_timeout
 
         if (
@@ -1252,7 +1278,7 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
         # interval for the rest of the kernel channels.
         return cull_idle_timeout + 60
 
-    async def receive_connection_info(self):
+    async def receive_connection_info(self) -> bool:
         """
         Monitors the response address for connection info sent by the remote kernel launcher.
         """
@@ -1280,7 +1306,7 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
 
         return ready_to_connect
 
-    def _setup_connection_info(self, connect_info):
+    def _setup_connection_info(self, connect_info: dict) -> None:
         """
         Take connection info (returned from launcher or loaded from session persistence) and properly
         configure port variables for the 5 kernel and (possibly) the launcher communication port.  If
@@ -1350,7 +1376,7 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
 
         self._update_connection(connect_info)
 
-    def _update_connection(self, connect_info):
+    def _update_connection(self, connect_info: dict) -> None:
         """
         Updates the connection info member variables of the kernel manager.  Also pulls the PID and PGID
         info, if present, in case we need to use it for lifecycle management.
@@ -1385,7 +1411,7 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
             True  # allows for cleanup of local files (as necessary)
         )
 
-    def _close_response_socket(self):
+    def _close_response_socket(self) -> None:
         # If there's a response-socket, close it since its no longer needed.
         if self.response_socket:
             try:
@@ -1396,7 +1422,7 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
                 pass  # tolerate exceptions here since we don't need this socket and would like ot continue
             self.response_socket = None
 
-    def _extract_pid_info(self, connect_info):
+    def _extract_pid_info(self, connect_info: dict) -> None:
         """
         Extracts any PID, PGID info from the payload received on the response socket.
         """
@@ -1464,7 +1490,7 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
         self.tunnel_processes.clear()
         super().cleanup()
 
-    def _send_listener_request(self, request, shutdown_socket=False):
+    def _send_listener_request(self, request: dict, shutdown_socket: bool = False) -> None:
         """
         Sends the request dictionary to the kernel listener via the comm port.  Caller is responsible for
         handling any exceptions.
@@ -1601,7 +1627,7 @@ class RemoteProcessProxy(BaseProcessProxyABC, metaclass=abc.ABCMeta):
             # communication socket (comm_ip, comm_port) members as well.
             self._setup_connection_info(process_info["tunneled_connect_info"])
 
-    def log_and_raise(self, http_status_code=None, reason=None):
+    def log_and_raise(self, http_status_code: int = None, reason: str = None):
         """
         Override log_and_raise method in order to verify that the response socket is properly closed
         before raise exception

--- a/enterprise_gateway/services/processproxies/spark_operator.py
+++ b/enterprise_gateway/services/processproxies/spark_operator.py
@@ -3,19 +3,20 @@
 
 import os
 
+from ..kernels.remotemanager import RemoteKernelManager
 from .crd import CustomResourceProcessProxy, client
 
 enterprise_gateway_namespace = os.environ.get("EG_NAMESPACE", "default")
 
 
 class SparkOperatorProcessProxy(CustomResourceProcessProxy):
-    def __init__(self, kernel_manager, proxy_config):
+    def __init__(self, kernel_manager: RemoteKernelManager, proxy_config: dict):
         super().__init__(kernel_manager, proxy_config)
         self.group = "sparkoperator.k8s.io"
         self.version = "v1beta2"
         self.plural = "sparkapplications"
 
-    def get_container_status(self, iteration):
+    def get_container_status(self, iteration: int) -> str:
         pod_status = pod_info = None
 
         try:


### PR DESCRIPTION
Pull Request for issue #851 
A couple of notes on my process for making the type hints and an ask for some assistance:
1. As noted in the inline comments, I could use some help with the typing on ConductorClusterProcessProxy. Mainly around the Conductor API responses as I am not familiar with it nor could I find documentation on it that looked right for the APIs being hit in these methods.
2. In the case of abstract classes (BaseProcessProxyABC and RemoteProcessProxy) I erred on the side of adding hints only to methods that were not implemented in subclasses. For ex. I added hints for all the `_xyz` methods in the abstract classes but not methods such as `poll`, `launch_process`, etc. I did this because the implementation classes may use different types for arguments or return object than the base abstract classes. Although I am open to changing this approach if it is not best practice.
Thanks!