### PR TITLE
Enable ability to not filter kernels in container deployments

### DIFF
--- a/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
@@ -30,12 +30,20 @@ EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"'r_docker','python_docker','python_t
 export EG_KERNEL_WHITELIST=`echo ${EG_KERNEL_WHITELIST} | sed 's/[][]//g'` # sed is used to strip off surrounding brackets as they should no longer be included.
 export EG_DEFAULT_KERNEL_NAME=${EG_DEFAULT_KERNEL_NAME:-python_docker}
 
+# Determine whether the kernels-allowed list should be added to the start command.
+# This is conveyed via a 'null' value for the env - which indicates no kernel names
+# were used in the helm chart.
+allowed_kernels_option="--KernelSpecManager.whitelist=[${EG_KERNEL_WHITELIST}]"
+if [ "${EG_KERNEL_WHITELIST}" == 'null' ]; then
+	allowed_kernels_option=""
+fi
+
 
 echo "Starting Jupyter Enterprise Gateway..."
 
 exec jupyter enterprisegateway \
 	--log-level=${EG_LOG_LEVEL} \
-	--KernelSpecManager.whitelist=[${EG_KERNEL_WHITELIST}] \
+	${allowed_kernels_option} \
 	--RemoteMappingKernelManager.cull_idle_timeout=${EG_CULL_IDLE_TIMEOUT} \
 	--RemoteMappingKernelManager.cull_interval=${EG_CULL_INTERVAL} \
 	--RemoteMappingKernelManager.cull_connected=${EG_CULL_CONNECTED} \

--- a/etc/kubernetes/helm/enterprise-gateway/values.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -76,7 +76,9 @@ kernel:
   launchTimeout: 60
   # Timeout for an idle kernel before its culled in seconds. Default is 1 hour.
   cullIdleTimeout: 3600
-  # List of kernel names that are available for use.
+  # List of kernel names that are available for use. To allow additional kernelspecs without
+  # requiring redeployment (and assuming kernelspecs are mounted or otherwise accessible
+  # outside the pod), comment out (or remove) the entries, leaving only `whitelist:`.
   whitelist:
     - r_kubernetes
     - python_kubernetes


### PR DESCRIPTION
As discussed in #1127, there is currently no way to easily enable dynamic kernelspec additions to containerized deployments because the deployment scripts always specific kernelspec entries.  Since dynamic kernelspec additions are default behaviors (when kernelspecs are not explicitly listed in the configuration), we should enable similar support in containerized deployments.  This pull request enables that functionality.

The `start-enterprise-gateway.sh` that is the `CMD` in the enterprise-gateway image has been modified to detect if the `EG_KERNEL_WHITELIST` env has a value of `null`.  When that value is detected, the `--KernelSpecManager.whitelist` command-line option is omitted, thereby exposing all kernelspecs configured into the image.  It is presumed that deployments wishing to dynamically add kernelspec definitions have mounted the `/usr/local/share/jupyter/kernels` directory (or otherwise made its update available).  Updates made to that directory will be automatically picked up when kernelspecs are refreshed.

A value of `null` was used for `EG_KERNEL_WHITELIST` to make this determination because that is the value Helm will set when the `whitelist:` entry of the `values.yaml` has no entries.  This allows operators to easily remove (or comment out) all existing kernelspec entries to enable this functionality.

Resolves: #1127