### PR TITLE
Add kernel launch sequence diagram to contributors guide

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -5,6 +5,7 @@ pydata_sphinx_theme
 sphinx
 sphinx-markdown-tables
 sphinx_book_theme
+sphinxcontrib-mermaid
 sphinxcontrib-openapi
 sphinxcontrib_github_alt
 sphinxemoji

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,3 +1,6 @@
 body div.sphinxsidebarwrapper p.logo {
   text-align: left;
 }
+.mermaid svg {
+    height: 100%;
+}

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -2,5 +2,5 @@ body div.sphinxsidebarwrapper p.logo {
   text-align: left;
 }
 .mermaid svg {
-    height: 100%;
+  height: 100%;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
     "sphinxcontrib_github_alt",
+    "sphinxcontrib.mermaid",
     "sphinxcontrib.openapi",
     "sphinxemoji.sphinxemoji",
 ]
@@ -166,6 +167,12 @@ html_logo = "_static/jupyter-logo.png"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    'custom.css',
+]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -171,7 +171,7 @@ html_static_path = ["_static"]
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
 html_css_files = [
-    'custom.css',
+    "custom.css",
 ]
 
 # Add any extra paths that contain custom files (such as robots.txt or

--- a/docs/source/contributors/index.rst
+++ b/docs/source/contributors/index.rst
@@ -21,5 +21,6 @@ These pages target people who are interested in contributing directly to the Jup
    system-architecture
    docker
    devinstall
+   sequence-diagrams
    debug
    roadmap

--- a/docs/source/contributors/sequence-diagrams.md
+++ b/docs/source/contributors/sequence-diagrams.md
@@ -1,12 +1,13 @@
 # Sequence Diagrams
 
-The following consists of various sequence diagrams you might find helpful.  We plan to add
+The following consists of various sequence diagrams you might find helpful. We plan to add
 diagrams based on demand and contributions.
 
 ## Kernel launch: Jupyter Lab to Enterprise Gateway
+
 This diagram depicts the interactions between components when a kernel start request
 is submitted from Jupyter Lab running against [Jupyter Server configured to use
-Enterprise Gateway](../users/connecting-to-eg.md).  The diagram also includes the
+Enterprise Gateway](../users/connecting-to-eg.md). The diagram also includes the
 retrieval of kernel specifications (kernelspecs) prior to the kernel's initialization.
 
 ```{mermaid}

--- a/docs/source/contributors/sequence-diagrams.md
+++ b/docs/source/contributors/sequence-diagrams.md
@@ -1,0 +1,46 @@
+# Sequence Diagrams
+
+The following consists of various sequence diagrams you might find helpful.  We plan to add
+diagrams based on demand and contributions.
+
+## Kernel launch: Jupyter Lab to Enterprise Gateway
+This diagram depicts the interactions between components when a kernel start request
+is submitted from Jupyter Lab running against [Jupyter Server configured to use
+Enterprise Gateway](../users/connecting-to-eg.md).  The diagram also includes the
+retrieval of kernel specifications (kernelspecs) prior to the kernel's initialization.
+
+```{mermaid}
+    sequenceDiagram
+        participant JupyterLab
+        participant JupyterServer
+        participant EnterpriseGateway
+        participant ProcessProxy
+        participant Kernel
+        participant ResourceManager
+        Note left of JupyterLab: fetch kernelspecs
+        JupyterLab->>JupyterServer: https GET api/kernelspecs
+        JupyterServer->>EnterpriseGateway: https GET api/kernelspecs
+        EnterpriseGateway-->>JupyterServer: api/kernelspecs response
+        JupyterServer-->>JupyterLab: api/kernelspecs response
+
+        Note left of JupyterLab: kernel initialization
+        JupyterLab->>JupyterServer: https POST api/sessions
+        JupyterServer->>EnterpriseGateway: https POST api/kernels
+        EnterpriseGateway->>ProcessProxy: launch_process()
+        ProcessProxy->>Kernel: launch kernel
+        ProcessProxy->>ResourceManager: confirm startup
+        Kernel-->>ProcessProxy: connection info
+        ResourceManager-->>ProcessProxy: state & host info
+        ProcessProxy-->>EnterpriseGateway: complete connection info
+        EnterpriseGateway->>Kernel: TCP socket requests
+        Kernel-->>EnterpriseGateway: TCP socket handshakes
+        EnterpriseGateway-->>JupyterServer: api/kernels response
+        JupyterServer-->>JupyterLab: api/sessions response
+
+        JupyterLab->>JupyterServer: ws GET api/kernels
+        JupyterServer->>EnterpriseGateway: ws GET api/kernels
+        EnterpriseGateway->>Kernel: kernel_info_request message
+        Kernel-->>EnterpriseGateway: kernel_info_reply message
+        EnterpriseGateway-->>JupyterServer: websocket upgrade response
+        JupyterServer-->>JupyterLab: websocket upgrade response
+```


### PR DESCRIPTION
Inspired by the work @telamonian started on #1039 and given that a reasonable workaround has been identified for the [`sphinxcontrib-mermaid` issue](https://github.com/jupyter-server/enterprise_gateway/pull/1039#issuecomment-1044798410), I've gone ahead and incorporated Max's kernel-init-sequence diagram into a "Sequence Diagrams" section of the Contributors guide using the `mermaid` markdown approach.   The hope is that other diagrams will be contributed downstream.  We can also choose to relocate this diagram as we see fit.

Special thanks to @telamonian for getting this ball rolling. 

Here's a screenshot consisting of a portion of the diagram and surrounding area:
![image](https://user-images.githubusercontent.com/22599560/178852262-d6bd3f2d-d142-44df-8ec8-f9ffda3d75c6.png)

Co-authored-by: telamonian <telamonian@users.noreply.github.com>