### PR TITLE
Fix Makefile WHEEL_FILES list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ else
 endif
 
 
-#WHEEL_FILES:=$(shell find . -type f ! -path "./build/*" ! -path "./etc/*" ! -path "./docs/*" ! -path "./.git/*" ! -path "./.idea/*" ! -path "./dist/*" ! -path "./.image-*" )
-WHEEL_FILES:=$(shell find enterprise_gateway -type f )
+WHEEL_FILES:=$(shell find . -type f ! -path "./build/*" ! -path "./etc/*" ! -path "./docs/*" ! -path "./.git/*" ! -path "./.idea/*" ! -path "./dist/*" ! -path "./.image-*" ! -path "*/__pycache__/*" )
 WHEEL_FILE:=dist/jupyter_enterprise_gateway-$(VERSION)-py3-none-any.whl
 SDIST_FILE:=dist/jupyter_enterprise_gateway-$(VERSION).tar.gz
 DIST_FILES=$(WHEEL_FILE) $(SDIST_FILE)


### PR DESCRIPTION
During release build prep, I found an issue where a previous PR contained an inadvertent change to the `WHEEL_FILES` macro in the Makefile.  This PR reverts that change and extends the macro to also ignore any directories named `__pycache__`.

Without this change, the following issue would occur:
```
make clean dist test
make clean dist
make: *** No rule to make target `enterprise_gateway/tests/__pycache__/__init__.cpython-39.pyc', needed by `dist/jupyter_enterprise_gateway-3.0.0.dev0-py3-none-any.whl'.  Stop.
```
That is, the second cycle of `make clean dist` after performing a test would pickup a `.pvc` file in the `WHEEL_FILES` macro, leading to the issue - despite the fact that the `clean` target explicitly removes `__pycache__` directories.  I suspect that the `lint` step of `make dist` is interfering somehow and creating these directories, particular since _sometimes_ a `conftest`-related `.pvc` is displayed.