### PR TITLE
Address delayed shutdown behavior in k8s kernels

### DIFF
--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -150,7 +150,6 @@ class ContainerProcessProxy(RemoteProcessProxy):
         # See https://github.com/jupyter-server/enterprise_gateway/issues/827
         if container_status in self.get_initial_states():
             result = None
-
         return result
 
     def send_signal(self, signum: int) -> bool | None:
@@ -184,12 +183,10 @@ class ContainerProcessProxy(RemoteProcessProxy):
 
         return result
 
-    def cleanup(self) -> None:
-        # Since container objects don't necessarily go away on their own, we need to perform the same
-        # cleanup we'd normally perform on forced kill situations.
-
-        self.kill()
-        super().cleanup()
+    def shutdown_listener(self):
+        super().shutdown_listener()
+        if self.container_name:  # We only have something to terminate if we have a name
+            self.terminate_container_resources()
 
     async def confirm_remote_startup(self) -> None:
         """Confirms the container has started and returned necessary connection information."""


### PR DESCRIPTION
This pull request attempts to address the delay seen when shutting down k8s-managed kernels.  I believe the issue is because the pod (and namespace if not BYO namespace) is not terminated when the kernel process has stopped.  Previously, the pod/namespace is not deleted until the cleanup phase, but these changes move the container resource termination to when the listener is shut down.  This allows the polling to check that the "kernel" has terminated to leverage the container status, which, previously, because it had yet to occur, was causing the fallback termination behavior to occur.

I suspect this was not a problem in older versions of kubernetes because (just a hunch) when the container's process terminated the container terminated.  However, I suspect k8s has "grown" enough where interaction with the resource manager is necessary and has introduced some delay.

There are several areas of race condition with starting/stopping pods from other applications, so I think this improves on those, but may not necessarily be the final solution.