### PR TITLE
Ensure kernel session retrieve from resp is correct type

### DIFF
--- a/enterprise_gateway/services/sessions/kernelsessionmanager.py
+++ b/enterprise_gateway/services/sessions/kernelsessionmanager.py
@@ -530,7 +530,5 @@ class WebhookKernelSessionManager(KernelSessionManager):
         """
         self.log.debug("Loading saved session(s)")
         self._sessions.update(
-            KernelSessionManager.post_load_transformation(
-                kernel_session["kernel_session"]
-            )
+            KernelSessionManager.post_load_transformation(kernel_session["kernel_session"])
         )

--- a/enterprise_gateway/services/sessions/kernelsessionmanager.py
+++ b/enterprise_gateway/services/sessions/kernelsessionmanager.py
@@ -501,7 +501,7 @@ class WebhookKernelSessionManager(KernelSessionManager):
         if self.enable_persistence:
             response = requests.get(self.webhook_url, auth=self.auth)
             if response.status_code == 200:
-                kernel_sessions = response.content
+                kernel_sessions = response.json()
                 for kernel_session in kernel_sessions:
                     self._load_session_from_response(kernel_session)
             else:
@@ -517,7 +517,7 @@ class WebhookKernelSessionManager(KernelSessionManager):
             if kernel_id is not None:
                 response = requests.get(f"{self.webhook_url}/{kernel_id}", auth=self.auth)
                 if response.status_code == 200:
-                    kernel_session = response.content
+                    kernel_session = response.json()
                     self._load_session_from_response(kernel_session)
                 else:
                     self.log.error(response.raise_for_status())
@@ -531,6 +531,6 @@ class WebhookKernelSessionManager(KernelSessionManager):
         self.log.debug("Loading saved session(s)")
         self._sessions.update(
             KernelSessionManager.post_load_transformation(
-                json.loads(kernel_session)["kernel_session"]
+                kernel_session["kernel_session"]
             )
         )


### PR DESCRIPTION
In `load_sessions()`, we need to traverse an iterable list `kernel_sessions` to get `kernel_session` . However if we retrieve the response with `response.content`, it actually give us back byte string, and leads to iterate on byte char instead of a dict object. Therefore, this PR address the improper used `content` to `json()` and rm the `json.loads()` part in `_load_session_from_response`

[Test Plan]
Having a customized WebhookKernelSessionManager deploy on Kubernetes and works properly with these changes.