### PR TITLE
Update kernel manager library docs

### DIFF
--- a/docs/source/developers/kernel-library.md
+++ b/docs/source/developers/kernel-library.md
@@ -14,8 +14,8 @@ from enterprise_gateway.services.kernels.remotemanager import RemoteKernelManage
 with open("my_notebook.ipynb") as fp:
     test_notebook = nbformat.read(fp, as_version=4)
 
-client = NotebookClient(nb=test_notebook, kernel_manager_class=RemoteKernelManager, kernel_name='my_remote_kernel')
-client.execute()
+client = NotebookClient(nb=test_notebook, kernel_manager_class=RemoteKernelManager)
+client.execute(kernel_name='my_remote_kernel')
 ```
 
 The above code will execute the notebook on a kernel named `my_remote_kernel` using its configured `ProcessProxy`.

--- a/docs/source/developers/kernel-manager.md
+++ b/docs/source/developers/kernel-manager.md
@@ -21,8 +21,7 @@ with open("my_notebook.ipynb") as fp:
 gw_client = GatewayClient.instance()
 gw_client.url = "http://my-gateway-server.com:8888"
 
-client = NotebookClient(nb=test_notebook,
-                        kernel_manager_class=GatewayKernelManager)
+client = NotebookClient(nb=test_notebook, kernel_manager_class=GatewayKernelManager)
 client.execute(kernel_name='my_remote_kernel')
 ```
 

--- a/docs/source/developers/kernel-manager.md
+++ b/docs/source/developers/kernel-manager.md
@@ -22,9 +22,8 @@ gw_client = GatewayClient.instance()
 gw_client.url = "http://my-gateway-server.com:8888"
 
 client = NotebookClient(nb=test_notebook,
-                        kernel_manager_class=GatewayKernelManager,
-                        kernel_name='my_remote_kernel')
-client.execute()
+                        kernel_manager_class=GatewayKernelManager)
+client.execute(kernel_name='my_remote_kernel')
 ```
 
 In this case, `my_remote_kernel`'s kernel specification file actually resides on the Gateway server. `NotebookClient` will _think_ its talking to local `KernelManager` and `KernelClient` instances, when, in actuality, they are forwarding requests to (and getting response from) the Gateway server at 'http://my-gateway-server.com:8888'.


### PR DESCRIPTION
fix https://github.com/jupyter-server/enterprise_gateway/issues/978 
We need to pass the `kernel_name` as argument explicitly since setting it in the `NotebookClient` constructor time doesn't really propagate down to `GatewayKernelManager`