### PR TITLE
Collect docker logs regardless of previous test's success

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           make itest-yarn
       - name: Collect logs
+        if: success() || failure()
         run: |
           python --version
           pip --version


### PR DESCRIPTION
The CI tests have started failing the last few days with no related changes (so probably a dependency issue).  The problem is that I can't reproduce the failures, even with similar package versions, etc.   I noticed that the docker log collection will not occur if the integration tests (which rely on docker) don't succeed.  This change will perform that step regardless of the previous step's outcome.

Note, however, that should the unit tests fail (`make test`), the integration tests are not run and, as a result, the log collection step will fail since there's no docker instance from which to collect logs.  We _could_ go ahead and also run the integration tests unconditionally, but I felt that was getting us further away from a "fail fast" model, so choose to live with the log collection failures in this case.