### PR TITLE
Add references for installing spark operator on k8s

### DIFF
--- a/docs/source/contributors/system-architecture.md
+++ b/docs/source/contributors/system-architecture.md
@@ -132,7 +132,7 @@ built-in subclasses of `RemoteProcessProxy` ...
   makes all kinds of spark on k8s components better organized and easy to configure.
 
 ```{note}
-Before you run a kernel associated with `SparkOperatorProcessProxy`, please ensure that spark operator is installed in an existing namespace of your Kubernetes cluster.
+Before you run a kernel associated with `SparkOperatorProcessProxy`, ensure that the [Kubernetes Operator for Apache Spark is installed](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator#installation) in your Kubernetes cluster.
 ```
 
 You might notice that the last six process proxies do not necessarily control the _launch_ of the kernel. This is

--- a/docs/source/operators/deploy-kubernetes.md
+++ b/docs/source/operators/deploy-kubernetes.md
@@ -16,10 +16,15 @@ The following sample kernel specifications apply to Kubernetes deployments:
 - spark_R_kubernetes
 - spark_python_kubernetes
 - spark_scala_kubernetes
+- spark_python_operator
 
 Enterprise Gateway deployments use the [elyra/enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) image from the Enterprise Gateway dockerhub organization [elyra](https://hub.docker.com/r/elyra/) along with other kubernetes-based images. See [Docker Images](../contributors/docker.md) for image details.
 
 When deployed within a [spark-on-kubernetes](https://spark.apache.org/docs/latest/running-on-kubernetes.html) cluster, Enterprise Gateway can easily support cluster-managed kernels distributed across the cluster. Enterprise Gateway will also provide standalone (i.e., _vanilla_) kernel invocation (where spark contexts are not automatically created) which also benefits from their distribution across the cluster.
+
+```{note}
+If you plan to use kernel specifications derived from the `spark_python_operator` sample, ensure that the [Kubernetes Operator for Apache Spark is installed](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator#installation) in your Kubernetes cluster.
+```
 
 We are using helm templates to manage Kubernetes resource configurations, which allows an end-user to easily customize their Enterprise Gateway deployment.
 


### PR DESCRIPTION
When attempting to use the Kubernetes Operator for Apache Spark, issues can arise if the operator is not installed prior to its use.  This pull request addresses these issues in the following ways...

1. Exception handling logic has been added to `launch_custom_resource.py` to detect status `404` and, if encountered, replaces the [raised exception](https://github.com/jupyter-server/enterprise_gateway/issues/1167#issuecomment-1268625854) with a system exit message that instructs the user where to find installation instructions.  This message purposely injects surrounding newlines so that it stands out in the EG log.

```

ERROR: The Kubernetes Operator for Apache Spark does not appear to be installed.  See 'https://github.com/GoogleCloudPlatform/spark-on-k8s-operator#installation' for instructions, then retry the operation.

```
2. The Note in the existing Contributor's Guide (in the _System Architecture_ section) has been enhanced to include a link to the installation instructions.
![image](https://user-images.githubusercontent.com/22599560/196559401-047abb57-afa3-4ff3-9ac4-492d0b5d0e6d.png)
3. The Operators Guide (in the _Kubernetes deployments_ section) has added a reference to `spark_python_operator` as a Kubernetes-related specification and also includes a similar Note referencing installation instructions.
![image](https://user-images.githubusercontent.com/22599560/196559513-391456ab-c193-4f62-9dbc-4ed1847b86ad.png)

Resolves: #1169