### PR TITLE
Rename CRD kill method and incorporate terminate_custom_resources

### DIFF
--- a/enterprise_gateway/services/processproxies/crd.py
+++ b/enterprise_gateway/services/processproxies/crd.py
@@ -63,4 +63,3 @@ class CustomResourceProcessProxy(KubernetesProcessProxy):
             self.kernel_resource_name = None
 
         return result
-


### PR DESCRIPTION
Fixes #1167

This PR includes the changes suggested in https://github.com/jupyter-server/enterprise_gateway/issues/1167#issuecomment-1267584529 
- renamed `kill()` to `terminate_container_resources()`
- pull logic in `terminate_custom_resources()` into the appropriate place in `terminate_container_resources()`

Prior to these changes, the spark operator pods lingered without being terminated on kernel change despite the pod logs indicating that the shutdown signal as received.
```
[I 2022-10-19 16:01:07,027.027 launch_ipykernel] server_listener got request: {'signum': 2}
[I 2022-10-19 16:01:07,028.028 launch_ipykernel] server_listener got request: {'shutdown': 1}
```

Now, pods are deleted on kernel change as expected. @vivekbhide also confirmed as such in https://github.com/jupyter-server/enterprise_gateway/issues/1167#issuecomment-1269282302