### PR TITLE
Fix helm version handling and package naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ DIST_FILES=$(WHEEL_FILE) $(SDIST_FILE)
 
 HELM_DESIRED_VERSION:=v3.8.2  # Pin the version of helm to use (v3.8.2 is latest as of 4/21/22)
 HELM_CHART_VERSION:=$(shell grep version: etc/kubernetes/helm/enterprise-gateway/Chart.yaml | sed 's/version: //')
-HELM_CHART:=dist/enterprise-gateway-$(HELM_CHART_VERSION).tgz
+HELM_CHART_PACKAGE:=dist/enterprise-gateway-$(HELM_CHART_VERSION).tgz
+HELM_CHART:=dist/jupyter_enterprise_gateway_helm-$(VERSION).tar.gz
 HELM_CHART_DIR:=etc/kubernetes/helm/enterprise-gateway
 HELM_CHART_FILES:=$(shell find $(HELM_CHART_DIR) -type f ! -name .DS_Store)
 HELM_INSTALL_DIR?=/usr/local/bin
@@ -99,7 +100,7 @@ $(SDIST_FILE): $(WHEEL_FILES)
 	pip install build && python -m build --sdist . \
 		&& rm -rf *.egg-info && chmod 0755 dist/*.*
 
-helm-chart: helm-install helm-lint $(HELM_CHART) ## Make helm chart distribution
+helm-chart: helm-install $(HELM_CHART) ## Make helm chart distribution
 
 helm-install: $(HELM_INSTALL_DIR)/helm
 
@@ -116,7 +117,9 @@ helm-clean: # Remove any .DS_Store files that might wind up in the package
 	$(shell find etc/kubernetes/helm -type f -name '.DS_Store' -exec rm -f {} \;)
 
 $(HELM_CHART): $(HELM_CHART_FILES)
+	make helm-lint
 	helm package $(HELM_CHART_DIR) -d dist
+	mv $(HELM_CHART_PACKAGE) $(HELM_CHART)  # Rename output to match other assets
 
 dist: lint bdist sdist kernelspecs helm-chart ## Make source, binary, kernelspecs and helm chart distributions to dist folder
 

--- a/docs/source/operators/deploy-kubernetes.md
+++ b/docs/source/operators/deploy-kubernetes.md
@@ -65,7 +65,7 @@ Alternatively, the helm chart tarball is also accessible as an asset on our [rel
 
 ```bash
 helm  upgrade --install  enterprise-gateway \
-  https://github.com/jupyter-server/enterprise_gateway/releases/download/[VERSION]/jupyter_enterprise_gateway_helm-[VERSION].tgz \
+  https://github.com/jupyter-server/enterprise_gateway/releases/download/[VERSION]/jupyter_enterprise_gateway_helm-[VERSION].tar.gz \
    --kube-context [mycluster-context-name] \
    --namespace [namespace-name]
 ```

--- a/etc/kubernetes/helm/enterprise-gateway/Chart.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart to deploy Jupyter Enterprise Gateway
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0-dev0-rc0-dev0-b0
+version: 3.1.0-dev0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/release.sh
+++ b/release.sh
@@ -201,7 +201,7 @@ function update_version_to_release {
     # We need to inject "-" prior to pre-release suffices for 'version:' since it follows strict semantic version rules.
     # For example 3.0.0rc1 -> 3.0.0-rc1
     k8s_version=`echo $RELEASE_VERSION | sed 's/\([0-9]\)\([a-z]\)/\1-\2/'`
-    sed -i .bak "s@version: [0-9,\.,a-z]*@version: $k8s_version@g" etc/kubernetes/helm/enterprise-gateway/Chart.yaml
+    sed -i .bak "s@version: [0-9,\.,a-z,-]*@version: $k8s_version@g" etc/kubernetes/helm/enterprise-gateway/Chart.yaml
 
     sed -i .bak "s@elyra/enterprise-gateway:dev@elyra/enterprise-gateway:$RELEASE_VERSION@g" etc/kubernetes/helm/enterprise-gateway/values.yaml
     sed -i .bak "s@elyra/kernel-image-puller:dev@elyra/kernel-image-puller:$RELEASE_VERSION@g" etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -225,7 +225,7 @@ function update_version_to_development {
     # We need to replace ".devN" suffix with "-devN for 'version:' since it follows strict semantic version rules.
     # For example 3.0.0.dev1 -> 3.0.0-dev1
     k8s_version=`echo $DEVELOPMENT_VERSION | sed 's/\.\(dev\)/-\1/'`
-    sed -i .bak "s@version: [0-9,\.,a-z]*@version: $k8s_version@g" etc/kubernetes/helm/enterprise-gateway/Chart.yaml
+    sed -i .bak "s@version: [0-9,\.,a-z,-]*@version: $k8s_version@g" etc/kubernetes/helm/enterprise-gateway/Chart.yaml
 
     sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/kubernetes/helm/enterprise-gateway/values.yaml
     sed -i .bak "s@elyra/kernel-image-puller:$RELEASE_VERSION@elyra/kernel-image-puller:dev@g" etc/kubernetes/helm/enterprise-gateway/values.yaml


### PR DESCRIPTION
The helm version (whose format differs from that of the release version format) was not being handled correctly via the `release.sh` script.  This pull request addresses that by recognizing hyphens.

In addition, the asset produced by `make helm-chart` (actually via the `helm package`) command, does not follow the same naming convention as that of the other assets we include.  This PR renames the file to that of the other assets (and actually closer to what we originally documented - whose suffix is updated in this PR as well).


Fixes: #1177 