### PR TITLE
Fix version portion of download command to refer to tag name

### DIFF
--- a/docs/source/operators/deploy-kubernetes.md
+++ b/docs/source/operators/deploy-kubernetes.md
@@ -65,7 +65,7 @@ Alternatively, the helm chart tarball is also accessible as an asset on our [rel
 
 ```bash
 helm  upgrade --install  enterprise-gateway \
-  https://github.com/jupyter-server/enterprise_gateway/releases/download/[VERSION]/jupyter_enterprise_gateway_helm-[VERSION].tar.gz \
+  https://github.com/jupyter-server/enterprise_gateway/releases/download/v[VERSION]/jupyter_enterprise_gateway_helm-[VERSION].tar.gz \
    --kube-context [mycluster-context-name] \
    --namespace [namespace-name]
 ```


### PR DESCRIPTION
While troubleshooting an issue, I discovered the example `helm install` command was not correct in that the first occurrence of `[VERSION]` in the example should be prefixed with `v` because it represents the tag name.  This pull request fixes the example.