### PR TITLE
[feature] add support for manage service and configmap in kernel-pod

### DIFF
--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -147,7 +147,7 @@ def launch_kubernetes_kernel(
             elif k8s_obj["kind"] == "Service":
                 if pod_template_file is None:
                     if pod_created is not None:
-                        # Create link dependance between pod and service, usefull to delete service when kernel stop
+                        # Create dependency between pod and service, useful to delete service when kernel stops
                         k8s_obj["metadata"]["ownerReferences"] = [
                             {
                                 "apiVersion": "v1",

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -148,7 +148,14 @@ def launch_kubernetes_kernel(
                 if pod_template_file is None:
                     if pod_created is not None:
                         # Create link dependance between pod and service, usefull to delete service when kernel stop
-                        k8s_obj['metadata']['ownerReferences'] = [{'apiVersion':'v1','kind':'pod','name':str(pod_created.metadata.name),'uid':str(pod_created.metadata.uid)}]
+                        k8s_obj["metadata"]["ownerReferences"] = [
+                            {
+                                "apiVersion": "v1",
+                                "kind": "pod",
+                                "name": str(pod_created.metadata.name),
+                                "uid": str(pod_created.metadata.uid),
+                            }
+                        ]
                         client.CoreV1Api(client.ApiClient()).create_namespaced_service(
                             body=k8s_obj, namespace=kernel_namespace
                         )
@@ -156,7 +163,14 @@ def launch_kubernetes_kernel(
                 if pod_template_file is None:
                     if pod_created is not None:
                         # Create link dependance between pod and configmap, usefull to delete service when kernel stop
-                        k8s_obj['metadata']['ownerReferences'] = [{'apiVersion':'v1','kind':'pod','name':str(pod_created.metadata.name),'uid':str(pod_created.metadata.uid)}]
+                        k8s_obj["metadata"]["ownerReferences"] = [
+                            {
+                                "apiVersion": "v1",
+                                "kind": "pod",
+                                "name": str(pod_created.metadata.name),
+                                "uid": str(pod_created.metadata.uid),
+                            }
+                        ]
                         client.CoreV1Api(client.ApiClient()).create_namespaced_config_map(
                             body=k8s_obj, namespace=kernel_namespace
                         )

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -118,6 +118,7 @@ def launch_kubernetes_kernel(
     # https://github.com/jupyter-server/enterprise_gateway/tree/main/enterprise_gateway/services/processproxies/k8s.py
     #
     pod_template = None
+    pod_created = None
     kernel_namespace = keywords["kernel_namespace"]
     k8s_objs = yaml.safe_load_all(k8s_yaml)
     for k8s_obj in k8s_objs:
@@ -126,7 +127,7 @@ def launch_kubernetes_kernel(
                 #  print("{}".format(k8s_obj))  # useful for debug
                 pod_template = extend_pod_env(k8s_obj)
                 if pod_template_file is None:
-                    client.CoreV1Api(client.ApiClient()).create_namespaced_pod(
+                    pod_created = client.CoreV1Api(client.ApiClient()).create_namespaced_pod(
                         body=k8s_obj, namespace=kernel_namespace
                     )
             elif k8s_obj["kind"] == "Secret":
@@ -142,6 +143,24 @@ def launch_kubernetes_kernel(
             elif k8s_obj["kind"] == "PersistentVolume":
                 if pod_template_file is None:
                     client.CoreV1Api(client.ApiClient()).create_persistent_volume(body=k8s_obj)
+
+            elif k8s_obj["kind"] == "Service":
+                if pod_template_file is None:
+                    if pod_created is not None:
+                        # Create link dependance between pod and service, usefull to delete service when kernel stop
+                        k8s_obj['metadata']['ownerReferences'] = [{'apiVersion':'v1','kind':'pod','name':str(pod_created.metadata.name),'uid':str(pod_created.metadata.uid)}]
+                        client.CoreV1Api(client.ApiClient()).create_namespaced_service(
+                            body=k8s_obj, namespace=kernel_namespace
+                        )
+            elif k8s_obj["kind"] == "ConfigMap":
+                if pod_template_file is None:
+                    if pod_created is not None:
+                        # Create link dependance between pod and configmap, usefull to delete service when kernel stop
+                        k8s_obj['metadata']['ownerReferences'] = [{'apiVersion':'v1','kind':'pod','name':str(pod_created.metadata.name),'uid':str(pod_created.metadata.uid)}]
+                        client.CoreV1Api(client.ApiClient()).create_namespaced_config_map(
+                            body=k8s_obj, namespace=kernel_namespace
+                        )
+
             else:
                 sys.exit(
                     f"ERROR - Unhandled Kubernetes object kind '{k8s_obj['kind']}' found in yaml file - "

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -162,7 +162,7 @@ def launch_kubernetes_kernel(
             elif k8s_obj["kind"] == "ConfigMap":
                 if pod_template_file is None:
                     if pod_created is not None:
-                        # Create link dependance between pod and configmap, usefull to delete service when kernel stop
+                        # Create dependency between pod and configmap, useful to delete service when kernel stops
                         k8s_obj["metadata"]["ownerReferences"] = [
                             {
                                 "apiVersion": "v1",


### PR DESCRIPTION
Problem Statement
---
We need to create service and configmap per kernel pod for launch spark driver without cluster mode (because we cannot use SparkContext to add jars.package option and other things)

Feature Description
---
The PR allow add kind service and configmap in kernel-pod.yaml.j2 and add ownerReference to kernel pod in new object (usefull when delete kernel)
Delete all namespace can resolv the problèm but we prefer not to keep a ghost object

Exemple kernel-pod.yaml : 

```
<default pod template>
---
apiVersion: v1
kind: Service
metadata:
  name: svc-{{ kernel_pod_name }}
  namespace: "{{ kernel_namespace }}"
  labels:
    kernel_id: "{{ kernel_id }}"
    app: enterprise-gateway
    component: kernel
    source: kernel-pod.yaml
spec:
  selector:
    app: enterprise-gateway
    component: kernel
    kernel_id: "{{ kernel_id }}"
    spark-role: driver
  ports:
  - name: spark-driver-rpc-port
    protocol: TCP
    port: 7078
    target: 7078
  - name: blockmanager
    port: 7079
    protocol: TCP
    targetPort: 7079
  - name: spark-ui
    port: 4040
    protocol: TCP
    targetPort: 4040
  sessionAffinity: None
  type: ClusterIP
```