### PR TITLE
Flow kernel-class-name to kernel container if specified in kernel specification

### DIFF
--- a/etc/kernel-launchers/bootstrap/bootstrap-kernel.sh
+++ b/etc/kernel-launchers/bootstrap/bootstrap-kernel.sh
@@ -5,17 +5,27 @@ RESPONSE_ADDRESS=${RESPONSE_ADDRESS:-${EG_RESPONSE_ADDRESS}}
 PUBLIC_KEY=${PUBLIC_KEY:-${EG_PUBLIC_KEY}}
 KERNEL_LAUNCHERS_DIR=${KERNEL_LAUNCHERS_DIR:-/usr/local/bin/kernel-launchers}
 KERNEL_SPARK_CONTEXT_INIT_MODE=${KERNEL_SPARK_CONTEXT_INIT_MODE:-none}
+KERNEL_CLASS_NAME=${KERNEL_CLASS_NAME}
 
 echo $0 env: `env`
 
 launch_python_kernel() {
-    # Launch the python kernel launcher - which embeds the IPython kernel and listens for interrupts
-    # and shutdown requests from Enterprise Gateway.
+  # Launch the python kernel launcher - which embeds the IPython kernel and listens for interrupts
+  # and shutdown requests from Enterprise Gateway.
 
-    export JPY_PARENT_PID=$$  # Force reset of parent pid since we're detached
+  export JPY_PARENT_PID=$$  # Force reset of parent pid since we're detached
+
+  if [ -z "${KERNEL_CLASS_NAME}" ]
+  then
+    kernel_class_option = ""
+  else
+    kernel_class_option = "--kernel_class_name ${KERNEL_CLASS_NAME}"
+  fi
 
 	set -x
-	python ${KERNEL_LAUNCHERS_DIR}/python/scripts/launch_ipykernel.py --kernel-id ${KERNEL_ID} --port-range ${PORT_RANGE} --response-address ${RESPONSE_ADDRESS} --public-key ${PUBLIC_KEY} --spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
+	python ${KERNEL_LAUNCHERS_DIR}/python/scripts/launch_ipykernel.py --kernel-id ${KERNEL_ID} \
+	      --port-range ${PORT_RANGE} --response-address ${RESPONSE_ADDRESS} --public-key ${PUBLIC_KEY} \
+	      --spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE} ${kernel_class_option}
 	{ set +x; } 2>/dev/null
 }
 

--- a/etc/kernel-launchers/docker/scripts/launch_docker.py
+++ b/etc/kernel-launchers/docker/scripts/launch_docker.py
@@ -15,7 +15,9 @@ remove_container = bool(
 swarm_mode = bool(os.getenv("DOCKER_MODE", os.getenv("EG_DOCKER_MODE", "swarm")).lower() == "swarm")
 
 
-def launch_docker_kernel(kernel_id, port_range, response_addr, public_key, spark_context_init_mode):
+def launch_docker_kernel(
+    kernel_id, port_range, response_addr, public_key, spark_context_init_mode, kernel_class_name
+):
     # Launches a containerized kernel.
 
     # Can't proceed if no image was specified.
@@ -41,6 +43,8 @@ def launch_docker_kernel(kernel_id, port_range, response_addr, public_key, spark
     param_env["PUBLIC_KEY"] = public_key
     param_env["RESPONSE_ADDRESS"] = response_addr
     param_env["KERNEL_SPARK_CONTEXT_INIT_MODE"] = spark_context_init_mode
+    if kernel_class_name:
+        param_env["KERNEL_CLASS_NAME"] = kernel_class_name
 
     # Since the environment is specific to the kernel (per env stanza of kernelspec, KERNEL_ and EG_CLIENT_ENVS)
     # just add the env here.
@@ -135,6 +139,12 @@ if __name__ == "__main__":
         nargs="?",
         help="Indicates whether or how a spark context should be created",
     )
+    parser.add_argument(
+        "--kernel-class-name",
+        dest="kernel_class_name",
+        nargs="?",
+        help="Indicates the name of the kernel class to use.  Must be a subclass of 'ipykernel.kernelbase.Kernel'.",
+    )
 
     # The following arguments are deprecated and will be used only if their mirroring arguments have no value.
     # This means that the default value for --spark-context-initialization-mode (none) will need to come from
@@ -181,5 +191,8 @@ if __name__ == "__main__":
     spark_context_init_mode = (
         arguments["spark_context_init_mode"] or arguments["rpp_spark_context_init_mode"]
     )
+    kernel_class_name = arguments["kernel_class_name"]
 
-    launch_docker_kernel(kernel_id, port_range, response_addr, public_key, spark_context_init_mode)
+    launch_docker_kernel(
+        kernel_id, port_range, response_addr, public_key, spark_context_init_mode, kernel_class_name
+    )

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -71,6 +71,7 @@ def launch_kubernetes_kernel(
     spark_context_init_mode,
     pod_template_file,
     spark_opts_out,
+    kernel_class_name,
 ):
     # Launches a containerized kernel as a kubernetes pod.
 
@@ -97,6 +98,9 @@ def launch_kubernetes_kernel(
         os.environ["KERNEL_ID"] = kernel_id
     if spark_context_init_mode:
         os.environ["KERNEL_SPARK_CONTEXT_INIT_MODE"] = spark_context_init_mode
+    if kernel_class_name:
+        os.environ["KERNEL_CLASS_NAME"] = kernel_class_name
+
     os.environ["KERNEL_NAME"] = os.path.basename(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     )
@@ -300,6 +304,12 @@ if __name__ == "__main__":
         help="When present, additional spark options are written to file, "
         "no launch performed, requires --pod-template.",
     )
+    parser.add_argument(
+        "--kernel-class-name",
+        dest="kernel_class_name",
+        nargs="?",
+        help="Indicates the name of the kernel class to use.  Must be a subclass of 'ipykernel.kernelbase.Kernel'.",
+    )
 
     # The following arguments are deprecated and will be used only if their mirroring arguments have no value.
     # This means that the default value for --spark-context-initialization-mode (none) will need to come from
@@ -348,6 +358,7 @@ if __name__ == "__main__":
     )
     pod_template_file = arguments["pod_template_file"]
     spark_opts_out = arguments["spark_opts_out"]
+    kernel_class_name = arguments["kernel_class_name"]
 
     launch_kubernetes_kernel(
         kernel_id,
@@ -357,4 +368,5 @@ if __name__ == "__main__":
         spark_context_init_mode,
         pod_template_file,
         spark_opts_out,
+        kernel_class_name,
     )


### PR DESCRIPTION
This pull request updates the container-based launchers (kubernetes, docker) and the `bootstrap-kernel.sh` script used in the kernel images to recognize and flow `--kernel-class-name` values to the python launcher.

When set, python-based kernel containers will have a `KERNEL_CLASS_NAME` env value corresponding to the configured kernel class that is set in the `kernel.json` via `--kernel-class-name`.

Since our kernelspecs don't set this value, a good way to test is to exec into the EG pod/container and add 
```
    "--kernel-class-name",
    "ipykernel.ipkernel.IPythonKernel"
```
to the `argv` stanza, then confirm the environment values from within the launcher kernel.

Resolves #1184 