### PR TITLE
Allow KIP to pull images relative to kernel provisioners

### DIFF
--- a/etc/docker/kernel-image-puller/kernel_image_puller.py
+++ b/etc/docker/kernel-image-puller/kernel_image_puller.py
@@ -163,9 +163,11 @@ class KernelImagePuller:
         for key in k_specs.keys():
             metadata = k_specs.get(key).get("spec").get("metadata")
             if metadata is not None:
-                process_proxy = metadata.get("process_proxy")
-                if process_proxy is not None:
-                    config = process_proxy.get("config")
+                config_parent = metadata.get("process_proxy")
+                if config_parent is None:  # See if this is a provisioner
+                    config_parent = metadata.get("kernel_provisioner")
+                if config_parent is not None:
+                    config = config_parent.get("config")
                     if config is not None:
                         image_name = config.get("image_name")
                         if image_name is not None:


### PR DESCRIPTION
While working with the [Remove Provisioners](https://github.com/gateway-experiments/remote_provisioners), I found that the Kernel Image Puller (KIP) was not pre-pulling images configured for provisioners.  Since their kernel spec configurations are nearly identical wrt how images are defined (process proxies use a `process_proxy` stanza while provisioners use a `kernel_provisioner` stanza), it's trivial for KIP to support both.  

This PR adds code to attempt to access the `kernel_provisioner` stanza when the `process_proxy` stanza is not found in a given kernel spec.