### PR TITLE
Handle the case when pod and/or pvc has already been created

### DIFF
--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -158,10 +158,15 @@ def launch_kubernetes_kernel(
                         )
                     except ApiException as exc:
                         if _parse_k8s_exception(exc) == K8S_ALREADY_EXIST_REASON:
-                            pod_created = client.CoreV1Api(client.ApiClient()).list_namespaced_pod(
-                                namespace=kernel_namespace,
-                                label_selector="kernel_id={}".format(kernel_id), watch=False
-                            ).items[0]
+                            pod_created = (
+                                client.CoreV1Api(client.ApiClient())
+                                .list_namespaced_pod(
+                                    namespace=kernel_namespace,
+                                    label_selector=f"kernel_id={kernel_id}",
+                                    watch=False,
+                                )
+                                .items[0]
+                            )
                         else:
                             raise exc
             elif k8s_obj["kind"] == "Secret":
@@ -184,8 +189,7 @@ def launch_kubernetes_kernel(
                             raise exc
             elif k8s_obj["kind"] == "PersistentVolume":
                 if pod_template_file is None:
-                    client.CoreV1Api(client.ApiClient()
-                                     ).create_persistent_volume(body=k8s_obj)
+                    client.CoreV1Api(client.ApiClient()).create_persistent_volume(body=k8s_obj)
             elif k8s_obj["kind"] == "Service":
                 if pod_template_file is None:
                     if pod_created is not None:

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -79,7 +79,7 @@ def _parse_k8s_exception(exc: ApiException) -> str:
     """
     # more exception can be parsed, but at the time of implementation we only need this one
     if exc.status == 409:
-        if exc.reason == 'Conflict' and f'"reason":{K8S_ALREADY_EXIST_REASON}' in exc.body:
+        if exc.reason == "Conflict" and f'"reason":{K8S_ALREADY_EXIST_REASON}' in exc.body:
             return K8S_ALREADY_EXIST_REASON
     return ""
 
@@ -158,10 +158,15 @@ def launch_kubernetes_kernel(
                         )
                     except ApiException as exc:
                         if _parse_k8s_exception()(exc) == K8S_ALREADY_EXIST_REASON:
-                            pod_created = client.CoreV1Api(client.ApiClient()).list_namespaced_pod(
-                                namespace=kernel_namespace,
-                                label_selector="kernel_id={}".format(kernel_id), watch=False
-                            ).items[0]
+                            pod_created = (
+                                client.CoreV1Api(client.ApiClient())
+                                .list_namespaced_pod(
+                                    namespace=kernel_namespace,
+                                    label_selector=f"kernel_id={kernel_id}",
+                                    watch=False,
+                                )
+                                .items[0]
+                            )
                         else:
                             raise exc
             elif k8s_obj["kind"] == "Secret":
@@ -172,7 +177,9 @@ def launch_kubernetes_kernel(
             elif k8s_obj["kind"] == "PersistentVolumeClaim":
                 if pod_template_file is None:
                     try:
-                        client.CoreV1Api(client.ApiClient()).create_namespaced_persistent_volume_claim(
+                        client.CoreV1Api(
+                            client.ApiClient()
+                        ).create_namespaced_persistent_volume_claim(
                             body=k8s_obj, namespace=kernel_namespace
                         )
                     except ApiException as exc:
@@ -182,9 +189,7 @@ def launch_kubernetes_kernel(
                             raise exc
             elif k8s_obj["kind"] == "PersistentVolume":
                 if pod_template_file is None:
-                    client.CoreV1Api(
-                        client.ApiClient()
-                    ).create_persistent_volume(body=k8s_obj)
+                    client.CoreV1Api(client.ApiClient()).create_persistent_volume(body=k8s_obj)
             elif k8s_obj["kind"] == "Service":
                 if pod_template_file is None:
                     if pod_created is not None:

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -157,16 +157,11 @@ def launch_kubernetes_kernel(
                             body=k8s_obj, namespace=kernel_namespace
                         )
                     except ApiException as exc:
-                        if _parse_k8s_exception()(exc) == K8S_ALREADY_EXIST_REASON:
-                            pod_created = (
-                                client.CoreV1Api(client.ApiClient())
-                                .list_namespaced_pod(
-                                    namespace=kernel_namespace,
-                                    label_selector=f"kernel_id={kernel_id}",
-                                    watch=False,
-                                )
-                                .items[0]
-                            )
+                        if _parse_k8s_exception(exc) == K8S_ALREADY_EXIST_REASON:
+                            pod_created = client.CoreV1Api(client.ApiClient()).list_namespaced_pod(
+                                namespace=kernel_namespace,
+                                label_selector="kernel_id={}".format(kernel_id), watch=False
+                            ).items[0]
                         else:
                             raise exc
             elif k8s_obj["kind"] == "Secret":
@@ -183,13 +178,14 @@ def launch_kubernetes_kernel(
                             body=k8s_obj, namespace=kernel_namespace
                         )
                     except ApiException as exc:
-                        if _parse_k8s_exception()(exc) == K8S_ALREADY_EXIST_REASON:
+                        if _parse_k8s_exception(exc) == K8S_ALREADY_EXIST_REASON:
                             pass
                         else:
                             raise exc
             elif k8s_obj["kind"] == "PersistentVolume":
                 if pod_template_file is None:
-                    client.CoreV1Api(client.ApiClient()).create_persistent_volume(body=k8s_obj)
+                    client.CoreV1Api(client.ApiClient()
+                                     ).create_persistent_volume(body=k8s_obj)
             elif k8s_obj["kind"] == "Service":
                 if pod_template_file is None:
                     if pod_created is not None:

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -8,6 +8,7 @@ import urllib3
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from kubernetes import client, config
+from kubernetes.client.rest import ApiException
 
 urllib3.disable_warnings()
 
@@ -61,6 +62,26 @@ def extend_pod_env(pod_def: dict) -> dict:
 
     pod_def["spec"]["containers"][0]["env"] = env_stanza
     return pod_def
+
+
+# a popular reason that lasts many APIs but is not constantized in the client lib
+K8S_ALREADY_EXIST_REASON = "AlreadyExists"
+
+
+def _parse_k8s_exception(exc: ApiException) -> str:
+    """Parse the exception and return the error message from kubernetes api
+
+    Args:
+        exc (Exception): Exception object
+
+    Returns:
+        str: Error message from kubernetes api
+    """
+    # more exception can be parsed, but at the time of implementation we only need this one
+    if exc.status == 409:
+        if exc.reason == 'Conflict' and f'"reason":{K8S_ALREADY_EXIST_REASON}' in exc.body:
+            return K8S_ALREADY_EXIST_REASON
+    return ""
 
 
 def launch_kubernetes_kernel(
@@ -131,9 +152,18 @@ def launch_kubernetes_kernel(
                 #  print("{}".format(k8s_obj))  # useful for debug
                 pod_template = extend_pod_env(k8s_obj)
                 if pod_template_file is None:
-                    pod_created = client.CoreV1Api(client.ApiClient()).create_namespaced_pod(
-                        body=k8s_obj, namespace=kernel_namespace
-                    )
+                    try:
+                        pod_created = client.CoreV1Api(client.ApiClient()).create_namespaced_pod(
+                            body=k8s_obj, namespace=kernel_namespace
+                        )
+                    except ApiException as exc:
+                        if _parse_k8s_exception()(exc) == K8S_ALREADY_EXIST_REASON:
+                            pod_created = client.CoreV1Api(client.ApiClient()).list_namespaced_pod(
+                                namespace=kernel_namespace,
+                                label_selector="kernel_id={}".format(kernel_id), watch=False
+                            ).items[0]
+                        else:
+                            raise exc
             elif k8s_obj["kind"] == "Secret":
                 if pod_template_file is None:
                     client.CoreV1Api(client.ApiClient()).create_namespaced_secret(
@@ -141,13 +171,20 @@ def launch_kubernetes_kernel(
                     )
             elif k8s_obj["kind"] == "PersistentVolumeClaim":
                 if pod_template_file is None:
-                    client.CoreV1Api(client.ApiClient()).create_namespaced_persistent_volume_claim(
-                        body=k8s_obj, namespace=kernel_namespace
-                    )
+                    try:
+                        client.CoreV1Api(client.ApiClient()).create_namespaced_persistent_volume_claim(
+                            body=k8s_obj, namespace=kernel_namespace
+                        )
+                    except ApiException as exc:
+                        if _parse_k8s_exception()(exc) == K8S_ALREADY_EXIST_REASON:
+                            pass
+                        else:
+                            raise exc
             elif k8s_obj["kind"] == "PersistentVolume":
                 if pod_template_file is None:
-                    client.CoreV1Api(client.ApiClient()).create_persistent_volume(body=k8s_obj)
-
+                    client.CoreV1Api(
+                        client.ApiClient()
+                    ).create_persistent_volume(body=k8s_obj)
             elif k8s_obj["kind"] == "Service":
                 if pod_template_file is None:
                     if pod_created is not None:
@@ -178,7 +215,6 @@ def launch_kubernetes_kernel(
                         client.CoreV1Api(client.ApiClient()).create_namespaced_config_map(
                             body=k8s_obj, namespace=kernel_namespace
                         )
-
             else:
                 sys.exit(
                     f"ERROR - Unhandled Kubernetes object kind '{k8s_obj['kind']}' found in yaml file - "


### PR DESCRIPTION
I am not entirely sure this is the best way to go, as well as I am aware we should keep the original script minimal to encourage downstream customizations. 

However, I find it confusing when out of the box, with the default kernel-pod.yaml.j2 (and kernel_volume enabled), we cannot have idempotency and jupyter EG will just return error because given the same kernel id, the same pod and pvc cannot be connected from the client side. 

This pull request shows my little adjustments to improve that. And while of course it can be applied to other resources, I would propose just keep it as minimal as possible and PVC as well as pod proves to be great targets (they can also be cleaned up by terminate_container_resources inside k8s.py process proxy)