### PR TITLE
Don't perform multi-arch image builds on dry runs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -246,7 +246,7 @@ if [[ "$RELEASE_PREPARE" == "true" ]]; then
     if [ -z "$DRY_RUN" ]; then
         make MULTIARCH_BUILD=y clean dist release docs docker-images
     else
-        make MULTIARCH_BUILD=y clean dist docs docker-images
+        make clean dist docs docker-images
     fi
     mkdir -p $WORK_DIR/$RELEASE_TAG
     cp $SOURCE_DIR/dist/jupyter_enterprise_gateway* $WORK_DIR/$RELEASE_TAG


### PR DESCRIPTION
When performing a dry run for the 3.1.0 release, I found that the multi-arch image builds took way too long.  Instead, I think it would be better to build the images in a non-multi-arch fashion so those images can first be tested prior to their push to dockerHub.  This essentially implies that multi-arch builds will occur AFTER a release.  That said, I did leave multi-arch image builds enabled for the non-dry-run builds.