### PR TITLE
Update python version, make docker-stacks tags consistent

### DIFF
--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/scipy-notebook:04f7f60d34a6
+ARG BASE_CONTAINER=jupyter/scipy-notebook:2022-01-24
 FROM $BASE_CONTAINER
 
 ENV PATH=$PATH:$CONDA_DIR/bin

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/r-notebook:04f7f60d34a6
+ARG BASE_CONTAINER=jupyter/r-notebook:2022-01-24
 FROM $BASE_CONTAINER
 
 RUN conda install --quiet --yes \


### PR DESCRIPTION
Just prior to cutting the release I noticed that the python used in some of the kernel images was 3.7.  This pull request bumps the python version to 3.9.7 by updating the corresponding docker-stacks tag values.  Since this tag was already in use by the `enterprise-gateway` and `kernel-tf-py` only `kernel-py` and `kenrel-r` base images have been updated to help minimize changes at this stage in the "release" cycle.