### PR TITLE
Adopt ruff and address lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     schedule:
       # Check for updates to GitHub Actions once a week (Mondays by default)
       interval: "weekly"
+  # Set update schedule for pip
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      # Check for updates to Python deps once a week (Mondays by default)
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,16 +59,12 @@ jobs:
           pip --version
           pip list
           docker logs itest-yarn
+      - name: Run linters
+        run: |
+          make lint
       - name: Bump versions
         run: |
           pipx run tbump --dry-run --no-tag --no-push 100.100.100rc0
-
-  pre_commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - uses: jupyterlab/maintainer-tools/.github/actions/pre-commit@v1
 
   link_check:
     runs-on: ubuntu-latest
@@ -128,7 +124,6 @@ jobs:
       - link_check
       - test_minimum_versions
       - build_docs
-      - pre_commit
       - test_sdist
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.166
+    rev: v0.0.169
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
@@ -15,24 +18,10 @@ repos:
       - id: forbid-new-submodules
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.19.2
     hooks:
-      - id: black
-        args: ["--line-length", "100"]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        files: \.py$
-        args: [--profile=black]
-
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.10.1
-    hooks:
-      - id: validate-pyproject
-        stages: [manual]
+      - id: check-github-workflows
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16
@@ -41,28 +30,13 @@ repos:
         additional_dependencies:
           [mdformat-gfm, mdformat-frontmatter, mdformat-footnote]
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.0
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
     hooks:
-      - id: pyupgrade
-        args: [--py37-plus]
+      - id: black
 
-  - repo: https://github.com/PyCQA/doc8
-    rev: v1.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.166
     hooks:
-      - id: doc8
-        args: [--max-line-length=200]
-
-  - repo: https://github.com/john-hen/Flake8-pyproject
-    rev: 1.2.2
-    hooks:
-      - id: Flake8-pyproject
-        alias: flake8
-        additional_dependencies:
-          ["flake8-bugbear==22.6.22", "flake8-implicit-str-concat==0.2.0"]
-        stages: [manual]
-
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.19.2
-    hooks:
-      - id: check-github-workflows
+      - id: ruff
+        args: ["--fix"]

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ lint: ## Check code style
 	@pip install -q -e ".[lint]"
 	@pip install -q pipx
 	ruff .
-	black --check --diff .
+	black --check --diff --color .
 	mdformat --check *.md
 	pipx run 'validate-pyproject[all]' pyproject.toml
 

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,12 @@ clean-env: ## Remove conda env
 	-conda env remove -n $(ENV) -y
 
 lint: ## Check code style
-	@pip install -q pre-commit
-	pre-commit run --all-files
+	@pip install -q -e ".[lint]"
+	@pip install -q pipx
+	ruff .
+	black --check --diff .
+	mdformat --check *.md
+	pipx run 'validate-pyproject[all]' pyproject.toml
 
 run-dev: test-install-wheel ## Make a server in jupyter_websocket mode
 	python enterprise_gateway

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,7 +57,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Jupyter Enterprise Gateway"
-copyright = "2022, Project Jupyter"
+copyright = "2022, Project Jupyter"  # noqa
 author = "Jupyter Server Team"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -68,7 +68,7 @@ _version_py = os.path.join("..", "..", "enterprise_gateway", "_version.py")
 version_ns = {}
 
 with open(_version_py) as version_file:
-    exec(version_file.read(), version_ns)
+    exec(version_file.read(), version_ns)  # noqa
 
 # The short X.Y version.
 version = version_ns["__version__"][:3]

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import queue as queue
 import time
 from threading import Thread
 from uuid import uuid4
@@ -7,11 +8,6 @@ from uuid import uuid4
 import requests
 import websocket
 from tornado.escape import json_decode, json_encode, utf8
-
-try:  # prefer python 3, fallback to 2
-    import queue as queue
-except ImportError:
-    import Queue as queue
 
 REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", 120))
 log_level = os.getenv("LOG_LEVEL", "INFO")

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -30,9 +30,7 @@ from .services.api.handlers import default_handlers as default_api_handlers
 from .services.kernels.handlers import default_handlers as default_kernel_handlers
 from .services.kernels.remotemanager import RemoteMappingKernelManager
 from .services.kernelspecs import KernelSpecCache
-from .services.kernelspecs.handlers import (
-    default_handlers as default_kernelspec_handlers,
-)
+from .services.kernelspecs.handlers import default_handlers as default_kernelspec_handlers
 from .services.sessions.handlers import default_handlers as default_session_handlers
 from .services.sessions.kernelsessionmanager import (
     FileKernelSessionManager,
@@ -202,7 +200,7 @@ class EnterpriseGatewayApp(EnterpriseGatewayConfigMixin, JupyterApp):
             try:
                 ssl.match_hostname(ssl_cert, authorized_hostname)
             except ssl.SSLCertVerificationError:
-                raise web.HTTPError(403, "Forbidden")
+                raise web.HTTPError(403, "Forbidden") from None
             base_prepare(self)
 
         handler[1].prepare = wrapped_prepare

--- a/enterprise_gateway/mixins.py
+++ b/enterprise_gateway/mixins.py
@@ -12,10 +12,21 @@ from typing import Any, Awaitable, Dict, List, Optional, Set
 
 from tornado import web
 from tornado.log import LogFormatter
-from traitlets import Bool, CaselessStrEnum, CBool, Instance, Integer
+from traitlets import (
+    Bool,
+    CaselessStrEnum,
+    CBool,
+    Instance,
+    Integer,
+    TraitError,
+    Type,
+    Unicode,
+    default,
+    observe,
+    validate,
+)
 from traitlets import List as ListTrait
 from traitlets import Set as SetTrait
-from traitlets import TraitError, Type, Unicode, default, observe, validate
 from traitlets.config import Configurable
 
 
@@ -198,7 +209,7 @@ class EnterpriseGatewayConfigMixin(Configurable):
         return os.getenv(self.base_url_env, os.getenv("KG_BASE_URL", self.base_url_default_value))
 
     # Token authorization
-    auth_token_env = "EG_AUTH_TOKEN"
+    auth_token_env = "EG_AUTH_TOKEN"  # noqa
     auth_token = Unicode(
         config=True, help="Authorization token required for all requests (EG_AUTH_TOKEN env var)"
     )
@@ -465,11 +476,12 @@ class EnterpriseGatewayConfigMixin(Configurable):
     def _validate_load_balancing_algorithm(self, proposal: Dict[str, str]) -> str:
         value = proposal["value"]
         try:
-            assert value in ["round-robin", "least-connection"]
+            if value not in ["round-robin", "least-connection"]:
+                raise AssertionError(f"Unrecognized proposal value {value}")
         except ValueError:
             raise TraitError(
                 f"Invalid load_balancing_algorithm value {value}, not in [round-robin,least-connection]"
-            )
+            ) from None
         return value
 
     # Yarn endpoint

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -22,11 +22,7 @@ from zmq import IO_THREADS, MAX_SOCKETS, Context
 
 from enterprise_gateway.mixins import EnterpriseGatewayConfigMixin
 
-from ..processproxies.processproxy import (
-    BaseProcessProxyABC,
-    LocalProcessProxy,
-    RemoteProcessProxy,
-)
+from ..processproxies.processproxy import BaseProcessProxyABC, LocalProcessProxy, RemoteProcessProxy
 from ..sessions.kernelsessionmanager import KernelSessionManager
 
 default_kernel_launch_timeout = float(os.getenv("EG_KERNEL_LAUNCH_TIMEOUT", "30"))
@@ -55,7 +51,7 @@ def import_item(name: str):
         try:
             pak = getattr(module, obj)
         except AttributeError:
-            raise ImportError("No module named %s" % obj)
+            raise ImportError("No module named %s" % obj) from None
         return pak
     else:
         # called with un-dotted string
@@ -252,7 +248,7 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
             await super().shutdown_kernel(kernel_id, now, restart)
         except KeyError as ke:  # this is hit for multiple shutdown request.
             self.log.exception(f"Exception while shutting down kernel: '{kernel_id}': {ke}")
-            raise web.HTTPError(404, "Kernel does not exist: %s" % kernel_id)
+            raise web.HTTPError(404, "Kernel does not exist: %s" % kernel_id) from None
 
     async def wait_for_restart_finish(self, kernel_id: str, action: str = "shutdown") -> None:
         kernel = self.get_kernel(kernel_id)

--- a/enterprise_gateway/services/kernelspecs/handlers.py
+++ b/enterprise_gateway/services/kernelspecs/handlers.py
@@ -5,10 +5,7 @@ import json
 from typing import Dict, List, Optional
 
 from jupyter_server.base.handlers import JupyterHandler
-from jupyter_server.services.kernelspecs.handlers import (
-    is_kernelspec_model,
-    kernelspec_model,
-)
+from jupyter_server.services.kernelspecs.handlers import is_kernelspec_model, kernelspec_model
 from jupyter_server.utils import ensure_async, url_unescape
 from tornado import web
 from traitlets import Set
@@ -131,7 +128,7 @@ class KernelSpecHandler(TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin, API
         try:
             spec = await ensure_async(ksc.get_kernel_spec(kernel_name))
         except KeyError:
-            raise web.HTTPError(404, "Kernel spec %s not found" % kernel_name)
+            raise web.HTTPError(404, "Kernel spec %s not found" % kernel_name) from None
         if is_kernelspec_model(spec):
             model = spec
         else:

--- a/enterprise_gateway/services/processproxies/conductor.py
+++ b/enterprise_gateway/services/processproxies/conductor.py
@@ -419,7 +419,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
             error_http_code = 500
             if self._get_application_id(True):
                 if self._query_app_state_by_driver_id(self.driver_id) != "WAITING":
-                    reason = "Kernel unavailable after {} seconds for driver_id {}, app_id {}, launch timeout: {}!".format(
+                    reason = "Kernel unavailable after {} seconds for driver_id {}, app_id {}, launch timeout: {}!"
+                    reason = reason.format(
                         time_interval,
                         self.driver_id,
                         self.application_id,

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -413,7 +413,7 @@ class BaseProcessProxyABC(metaclass=abc.ABCMeta):
         self.proxy_config = proxy_config
         # Initialize to 0 IP primarily so restarts of remote kernels don't encounter local-only enforcement during
         # relaunch (see jupyter_client.manager.start_kernel().
-        self.kernel_manager.ip = "0.0.0.0"
+        self.kernel_manager.ip = "0.0.0.0"  # noqa
         self.log = kernel_manager.log
 
         # extract the kernel_id string from the connection file and set the KERNEL_ID environment variable
@@ -533,7 +533,7 @@ class BaseProcessProxyABC(metaclass=abc.ABCMeta):
         kwargs.pop("kernel_headers", None)
         return launch_kernel(cmd, **kwargs)
 
-    def cleanup(self) -> None:
+    def cleanup(self) -> None:  # noqa
         """Performs optional cleanup after kernel is shutdown.  Child classes are responsible for implementations."""
         pass
 

--- a/enterprise_gateway/services/sessions/kernelsessionmanager.py
+++ b/enterprise_gateway/services/sessions/kernelsessionmanager.py
@@ -393,8 +393,10 @@ class FileKernelSessionManager(KernelSessionManager):
 class WebhookKernelSessionManager(KernelSessionManager):
     """
     Performs kernel session persistence operations against URL provided (EG_WEBHOOK_URL). The URL must have 4 endpoints
-    associated with it. 1 delete endpoint that takes a list of kernel ids in the body, 1 post endpoint that takes kernels id as a
-    url param and the kernel session as the body, 1 get endpoint that returns all kernel sessions, and 1 get endpoint that returns
+    associated with it. 1 delete endpoint that takes a list of kernel ids in
+    the body, 1 post endpoint that takes kernels id as a
+    url param and the kernel session as the body, 1 get endpoint that returns
+    all kernel sessions, and 1 get endpoint that returns
     a specific kernel session based on kernel id as url param.
     """
 
@@ -423,7 +425,7 @@ class WebhookKernelSessionManager(KernelSessionManager):
         return os.getenv(self.webhook_username_env, None)
 
     # Webhook Password
-    webhook_password_env = "EG_WEBHOOK_PASSWORD"
+    webhook_password_env = "EG_WEBHOOK_PASSWORD"  # noqa
     webhook_password = Unicode(
         config=True,
         allow_none=True,

--- a/enterprise_gateway/services/sessions/sessionmanager.py
+++ b/enterprise_gateway/services/sessions/sessionmanager.py
@@ -60,7 +60,7 @@ class SessionManager(LoggingConfigurable):
         kernel_name: Optional[str] = None,
         kernel_id: Optional[str] = None,
         *args,
-        **kwargs
+        **kwargs,
     ) -> dict:
         """Creates a session and returns its model.
 
@@ -91,7 +91,7 @@ class SessionManager(LoggingConfigurable):
         path: Optional[str] = None,
         kernel_id: Optional[str] = None,
         *args,
-        **kwargs
+        **kwargs,
     ) -> dict:
         """Saves the metadata for the session with the given `session_id`.
 

--- a/enterprise_gateway/tests/test_handlers.py
+++ b/enterprise_gateway/tests/test_handlers.py
@@ -376,7 +376,6 @@ class TestDefaults(TestHandlers):
         for _ in range(8):
             msg = yield ws.read_message()
             msg = json_decode(msg)
-            print(f"test_kernel_comm, msg_type: {msg['msg_type']}")
             if msg["msg_type"] == "kernel_info_reply":
                 break
         else:

--- a/enterprise_gateway/tests/test_mixins.py
+++ b/enterprise_gateway/tests/test_mixins.py
@@ -31,7 +31,7 @@ class TestableTokenAuthHandler(TokenAuthorizationMixin, SuperTokenAuthHandler):
 
     __test__ = False
 
-    def __init__(self, token=""):
+    def __init__(self, token=""):  # noqa
         self.settings = {"eg_auth_token": token}
         self.arguments = {}
         self.response = None

--- a/etc/docker/kernel-image-puller/kernel_image_puller.py
+++ b/etc/docker/kernel-image-puller/kernel_image_puller.py
@@ -236,8 +236,9 @@ class KernelImagePuller:
                     f"Previously pulled image '{image_name}' was not found - attempting pull..."
                 )
             elif self.image_exists(image_name):  # Yet to be pulled, consider pulled if exists
+                policy = self.policy
                 logger.info(
-                    f"Image '{image_name}' has not been pulled but exists, and policy is '{self.policy}'. Skipping pull."
+                    f"Image '{image_name}' has not been pulled but exists, and policy is '{policy}'. Skipping pull."
                 )
                 self.pulled_images.add(image_name)
                 return

--- a/etc/kernel-launchers/R/scripts/server_listener.py
+++ b/etc/kernel-launchers/R/scripts/server_listener.py
@@ -147,7 +147,7 @@ def _select_socket(lower_port, upper_port):
     retries = 0
     while not found_port:
         try:
-            sock.bind(("0.0.0.0", _get_candidate_port(lower_port, upper_port)))
+            sock.bind(("0.0.0.0", _get_candidate_port(lower_port, upper_port)))  # noqa
             found_port = True
         except Exception:
             retries = retries + 1
@@ -156,7 +156,7 @@ def _select_socket(lower_port, upper_port):
                     "Failed to locate port within range {}..{} after {} retries!".format(
                         lower_port, upper_port, max_port_range_retries
                     )
-                )
+                ) from None
     return sock
 
 
@@ -221,7 +221,7 @@ def server_listener(sock, parent_pid):
 def setup_server_listener(
     conn_filename, parent_pid, lower_port, upper_port, response_addr, kernel_id, public_key
 ):
-    ip = "0.0.0.0"
+    ip = "0.0.0.0"  # noqa
     key = str(uuid.uuid4()).encode()  # convert to bytes
 
     ports = _select_ports(5, lower_port, upper_port)

--- a/etc/kernel-launchers/docker/scripts/launch_docker.py
+++ b/etc/kernel-launchers/docker/scripts/launch_docker.py
@@ -83,7 +83,7 @@ def launch_docker_kernel(
             kwargs["workdir"] = param_env.get("KERNEL_WORKING_DIR")
         # kwargs['mounts'] = mounts   # Enable if necessary
         # print("service args: {}".format(kwargs))  # useful for debug
-        client.services.create(image_name, **kwargs)  # noqa
+        client.services.create(image_name, **kwargs)
     else:
         # volumes = {  # Enable if necessary
         #     "/usr/local/share/jupyter/kernels": {
@@ -102,7 +102,7 @@ def launch_docker_kernel(
             kwargs["working_dir"] = param_env.get("KERNEL_WORKING_DIR")
         # kwargs['volumes'] = volumes   # Enable if necessary
         # print("container args: {}".format(kwargs))  # useful for debug
-        client.containers.run(image_name, **kwargs)  # noqa
+        client.containers.run(image_name, **kwargs)
 
 
 if __name__ == "__main__":

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -173,15 +173,15 @@ def _validate_port_range(port_range):
                 raise RuntimeError(
                     f"Port range validation failed for range: '{port_range}'.  Range size must be at least "
                     f"{min_port_range_size} as specified by env EG_MIN_PORT_RANGE_SIZE"
-                )
+                ) from None
     except ValueError as ve:
         raise RuntimeError(
             f"Port range validation failed for range: '{port_range}'.  Error was: {ve}"
-        )
+        ) from None
     except IndexError as ie:
         raise RuntimeError(
             f"Port range validation failed for range: '{port_range}'.  Error was: {ie}"
-        )
+        ) from None
 
     return lower_port, upper_port
 
@@ -316,7 +316,7 @@ def _select_socket(lower_port, upper_port):
     retries = 0
     while not found_port:
         try:
-            sock.bind(("0.0.0.0", _get_candidate_port(lower_port, upper_port)))
+            sock.bind(("0.0.0.0", _get_candidate_port(lower_port, upper_port)))  # noqa
             found_port = True
         except Exception:
             retries = retries + 1
@@ -324,7 +324,7 @@ def _select_socket(lower_port, upper_port):
                 raise RuntimeError(
                     f"Failed to locate port within range {lower_port}..{upper_port} "
                     f"after {max_port_range_retries} retries!"
-                )
+                ) from None
     return sock
 
 
@@ -429,7 +429,7 @@ def import_item(name):
         try:
             pak = getattr(module, obj)
         except AttributeError:
-            raise ImportError("No module named %s" % obj)
+            raise ImportError("No module named %s" % obj) from None
         return pak
     else:
         # called with un-dotted string
@@ -577,7 +577,7 @@ if __name__ == "__main__":
     spark_init_mode = arguments["init_mode"] or arguments["rpp_init_mode"]
     cluster_type = arguments["cluster_type"] or arguments["rpp_cluster_type"]
     kernel_class_name = arguments["kernel_class_name"]
-    ip = "0.0.0.0"
+    ip = "0.0.0.0"  # noqa
 
     if connection_file is None and kernel_id is None:
         raise RuntimeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,8 +156,8 @@ ignore = [
 "C408",
 # N806 Variable `reasonErr` in function should be lowercase
 "N806", "N802", "N803",
-# I252 Relative imports from parent modules are banned
-"I252",
+# TID252 Relative imports from parent modules are banned
+"TID252",
 # E501 Line too long (110 > 100 characters)
 "E501",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ lint = [
   "black[jupyter]>=22.10.0",
   "mdformat>0.7",
   "mdformat-gfm>=0.3.5",
-  "ruff>=0.0.166"
+  "ruff>=0.0.169"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,12 @@ test = [
   "pre-commit",
   "websocket-client"
 ]
+lint = [
+  "black[jupyter]>=22.10.0",
+  "mdformat>0.7",
+  "mdformat-gfm>=0.3.5",
+  "ruff>=0.0.166"
+]
 
 [project.scripts]
 jupyter-enterprisegateway = "enterprise_gateway.enterprisegatewayapp:launch_instance"
@@ -126,22 +132,42 @@ exclude_lines = [
 "@(abc\\.)?abstractmethod",
 ]
 
-[tool.flake8]
-ignore = "E501, W503, E402"
-builtins = "c, get_config"
-exclude = [
-    ".cache",
-    ".github",
-    "docs",
+[tool.black]
+line-length = 100
+target-version = ["py37"]
+skip-string-normalization = true
+extend-exclude = "enterprise_gateway/.*ipynb"
+
+[tool.ruff]
+target-version = "py37"
+line-length = 100
+select = [
+  "A", "B", "C", "E", "F", "FBT", "I", "N", "Q", "RUF", "S", "T",
+  "UP", "W", "YTT",
 ]
-enable-extensions = "G"
-extend-ignore = [
-    "G001", "G002", "G004", "G200", "G201", "G202",
-    # black adds spaces around ':'
-    "E203",
+ignore = [
+# Q000 Single quotes found but double quotes preferred
+"Q000",
+# FBT001 Boolean positional arg in function definition
+"FBT001", "FBT002", "FBT003",
+# C901 `async_setup_kernel` is too complex (12)
+"C901",
+# C408 Unnecessary `dict` call (rewrite as a literal)
+"C408",
+# N806 Variable `reasonErr` in function should be lowercase
+"N806", "N802", "N803",
+# I252 Relative imports from parent modules are banned
+"I252",
+# E501 Line too long (110 > 100 characters)
+"E501",
 ]
-per-file-ignores = [
-    # B011: Do not call assert False since python -O removes these calls
-    # F841 local variable 'foo' is assigned to but never used
-    "enterprise_gateway/tests/*: B011", "F841",
-]
+
+[tool.ruff.per-file-ignores]
+# S101 Use of `assert` detected
+# F841 local variable 'foo' is assigned to but never used
+# S105 Possible hardcoded password: `"NeverHeardOf"`
+# T201 `print` found
+"enterprise_gateway/tests/*" = ["S101", "F841", "S105", "T201"]
+"enterprise_gateway/itests/*" = ["S101", "F841", "S105", "T201"]
+# T201 `print` found
+"etc/*" = ["T201"]


### PR DESCRIPTION
Adopt ruff, which is faster and replaces flake8, isort, and pyupgrade
Move linters from pre-commit to Makefile
Add pip to dependabot
Address typings which were not being checked by pre-commit...
