### PR TITLE
Fix kernel-spark-py and kernel-spark-r images

### DIFF
--- a/etc/docker/kernel-spark-py/Dockerfile
+++ b/etc/docker/kernel-spark-py/Dockerfile
@@ -32,12 +32,10 @@ RUN curl -s https://archive.apache.org/dist/spark/spark-${SPARK_VER}/spark-${SPA
     ln -s ${SPARK_HOME}-${SPARK_VER}-bin-hadoop2.7 $SPARK_HOME
 
 # Download entrypoint.sh from matching tag
-# Use tini from Anaconda installation
 RUN cd /opt/ && \
     wget https://raw.githubusercontent.com/apache/spark/v${SPARK_VER}/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh && \
     chmod a+x /opt/entrypoint.sh && \
-    sed -i 's/tini -s/tini -g/g' /opt/entrypoint.sh && \
-    ln -sfn /opt/conda/bin/tini /usr/bin/tini
+    sed -i 's/tini -s/tini -g/g' /opt/entrypoint.sh
 
 WORKDIR $SPARK_HOME/work-dir
 # Ensure that work-dir is writable by everyone

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -27,12 +27,10 @@ RUN curl -s https://archive.apache.org/dist/spark/spark-${SPARK_VER}/spark-${SPA
     ln -s ${SPARK_HOME}-${SPARK_VER}-bin-hadoop2.7 $SPARK_HOME
 
 # Download entrypoint.sh from matching tag
-# Use tini from Anaconda installation
 RUN cd /opt/ && \
     wget https://raw.githubusercontent.com/apache/spark/v${SPARK_VER}/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh && \
     chmod a+x /opt/entrypoint.sh && \
-    sed -i 's/tini -s/tini -g/g' /opt/entrypoint.sh && \
-    ln -sfn /opt/conda/bin/tini /usr/bin/tini
+    sed -i 's/tini -s/tini -g/g' /opt/entrypoint.sh
 
 WORKDIR $SPARK_HOME/work-dir
 # Ensure that work-dir is writable by everyone


### PR DESCRIPTION
Apparently, the "last minute" change made in #1207 for 3.1.0 came back to bite me!  Those base images do not include `/opt/conda/bin/tini` which we preferred over the default `/usr/bin/tini`.  As a result, the adjustments we make in our spark images that derive from the images built from those _docker-stacks_ images were DOA.  (What could possibly go wrong, right? :smile:)

This pull request removes the use of `/opt/conda/bin/tini` and merely performs the previous adjustment of `-s` to `-g` relative to `/usr/bin/tini`.

Fixes: #1216