### PR TITLE
Support building image with dedicated platform by specifying compatible docker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SA?=source activate
 ENV:=enterprise-gateway-dev
 SHELL:=/bin/bash
 MULTIARCH_BUILD?=
-TARGET_ARCH?=
+TARGET_ARCH?=undefined
 
 VERSION?=3.2.0.dev0
 SPARK_VERSION?=3.2.1

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SA?=source activate
 ENV:=enterprise-gateway-dev
 SHELL:=/bin/bash
 MULTIARCH_BUILD?=
+TARGET_ARCH?=
 
 VERSION?=3.2.0.dev0
 SPARK_VERSION?=3.2.1
@@ -156,10 +157,10 @@ kernel-images: ## Build kernel-based docker images
 docker-images: demo-base enterprise-gateway-demo kernel-images enterprise-gateway kernel-py kernel-spark-py kernel-r kernel-spark-r kernel-scala kernel-tf-py kernel-tf-gpu-py kernel-image-puller
 
 enterprise-gateway-demo kernel-images enterprise-gateway kernel-py kernel-spark-py kernel-r kernel-spark-r kernel-scala kernel-tf-py kernel-tf-gpu-py kernel-image-puller:
-	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) NO_CACHE=$(NO_CACHE) TAG=$(TAG) SPARK_VERSION=$(SPARK_VERSION) MULTIARCH_BUILD=$(MULTIARCH_BUILD) -C etc $@
+	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) NO_CACHE=$(NO_CACHE) TAG=$(TAG) SPARK_VERSION=$(SPARK_VERSION) MULTIARCH_BUILD=$(MULTIARCH_BUILD) TARGET_ARCH=$(TARGET_ARCH) -C etc $@
 
 demo-base:
-	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) NO_CACHE=$(NO_CACHE) TAG=$(SPARK_VERSION) SPARK_VERSION=$(SPARK_VERSION) MULTIARCH_BUILD=$(MULTIARCH_BUILD) -C etc $@
+	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) NO_CACHE=$(NO_CACHE) TAG=$(SPARK_VERSION) SPARK_VERSION=$(SPARK_VERSION) MULTIARCH_BUILD=$(MULTIARCH_BUILD) TARGET_ARCH=$(TARGET_ARCH) -C etc $@
 
 # Here for doc purposes
 clean-images: clean-demo-base ## Remove docker images (includes kernel-based images)

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -2,12 +2,14 @@
 # Distributed under the terms of the Modified BSD License.
 
 .PHONY: help clean clean-images clean-enterprise-gateway clean-enterprise-gateway-demo clean-demo-base \
-    clean-kernel-images clean-py clean-tf-py clean-tf-gpu-py clean-r clean-spark-r clean-scala toree-launcher \
-    kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker clean-kernel-image-puller
+		clean-kernel-images clean-py clean-tf-py clean-tf-gpu-py clean-r clean-spark-r clean-scala toree-launcher \
+		kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker clean-kernel-image-puller
 
 SA?=source activate
 ENV:=enterprise-gateway-dev
 SHELL:=/bin/bash
+SUPPORTED_ARCHS=linux/arm64 linux/amd64
+PLATFORM_ARCHS=`echo ${SUPPORTED_ARCHS} | sed "s/ /,/g"`
 
 # Docker attributes - hub organization and tag.  Modify accordingly
 HUB_ORG:=elyra
@@ -43,10 +45,10 @@ TOREE_LAUNCHER_FILES:=$(shell find kernel-launchers/scala/toree-launcher/src -ty
 ../build/kernelspecs: kernel-launchers/scala/lib  $(FILES_kernelspecs_all)
 	@rm -rf ../build/kernelspecs
 	@mkdir -p ../build/kernelspecs
-    # Seed the build tree with initial files
+		# Seed the build tree with initial files
 	cp -r kernelspecs ../build
-    # Distribute language and config-sensitive files.
-    # On-prem kernelspecs get launcher files in the kernelspec hierarchy
+		# Distribute language and config-sensitive files.
+		# On-prem kernelspecs get launcher files in the kernelspec hierarchy
 	@echo ../build/kernelspecs/python_distributed | xargs -t -n 1 cp -r kernel-launchers/python/scripts
 	@echo ../build/kernelspecs/dask_python_* | xargs -t -n 1 cp -r kernel-launchers/python/scripts
 	@echo ../build/kernelspecs/spark_python_{conductor*,yarn*} | xargs -t -n 1 cp -r kernel-launchers/python/scripts
@@ -57,12 +59,12 @@ TOREE_LAUNCHER_FILES:=$(shell find kernel-launchers/scala/toree-launcher/src -ty
 	@echo ../build/kernelspecs/spark_{python,R,scala}_kubernetes | xargs -t -n 1 cp -r kernel-launchers/kubernetes/*
 	@echo ../build/kernelspecs/{python,R,scala,python_tf,python_tf_gpu}_docker | xargs -t -n 1 cp -r kernel-launchers/docker/*
 	@echo ../build/kernelspecs/spark_python_operator | xargs -t -n 1 cp -r kernel-launchers/operators/*
-        # Populate kernel resources.  Because tensorflow is also python, it should be last.
+				# Populate kernel resources.  Because tensorflow is also python, it should be last.
 	@echo ../build/kernelspecs/*R* | xargs -t -n 1 cp -r kernel-resources/ir/*
 	@echo ../build/kernelspecs/*scala* | xargs -t -n 1 cp -r kernel-resources/apache_toree/*
 	@echo ../build/kernelspecs/*python* | xargs -t -n 1 cp -r kernel-resources/python/*
 	@echo ../build/kernelspecs/*tf* | xargs -t -n 1 cp -r kernel-resources/tensorflow/*
-    # Perform the copy again to enable local, per-kernel, overrides
+		# Perform the copy again to enable local, per-kernel, overrides
 	cp -r kernelspecs ../build
 	@(cd ../build/kernelspecs; find . -name 'kernel.json' -print0 | xargs -0 sed -i.bak "s/VERSION/$(TAG)/g"; find . -name *.bak -print0 | xargs -0 rm -f)
 	@mkdir -p ../dist
@@ -153,13 +155,15 @@ ifdef MULTIARCH_BUILD
 	@echo "starting buildx builder for $1"
 	-@(docker buildx rm $1)
 	(docker buildx create --use --name $1)
-	(cd ../build/docker/$1; docker buildx build ${NO_CACHE} --platform linux/arm64,linux/amd64 --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} --build-arg SPARK_VERSION=${SPARK_VERSION} -t $(HUB_ORG)/$1:$(TAG) . --push)
+	(cd ../build/docker/$1; docker buildx build ${NO_CACHE} --platform $(PLATFORM_ARCHS) --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} --build-arg SPARK_VERSION=${SPARK_VERSION} -t $(HUB_ORG)/$1:$(TAG) . --push)
 	@echo "remove builder instance $1"
 	-(docker buildx rm $1)
-else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), linux/arm64 linux/amd64))
+else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), $(SUPPORTED_ARCHS)))
+	@echo "Building docker image for $(TARGET_ARCH)"
 	(cd ../build/docker/$1; docker build ${NO_CACHE} --platform ${TARGET_ARCH} --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} --build-arg SPARK_VERSION=${SPARK_VERSION} -t $(HUB_ORG)/$1:$(TAG) .)
 	@-docker images $(HUB_ORG)/$1:$(TAG)
 else
+	@echo "TARGET_ARCH not defined or not in supported platforms: $(PLATFORM_ARCHS). Building docker image for default platform"
 	(cd ../build/docker/$1; docker build ${NO_CACHE} --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} --build-arg SPARK_VERSION=${SPARK_VERSION} -t $(HUB_ORG)/$1:$(TAG) .)
 	@-docker images $(HUB_ORG)/$1:$(TAG)
 endif

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -156,6 +156,9 @@ ifdef MULTIARCH_BUILD
 	(cd ../build/docker/$1; docker buildx build ${NO_CACHE} --platform linux/arm64,linux/amd64 --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} --build-arg SPARK_VERSION=${SPARK_VERSION} -t $(HUB_ORG)/$1:$(TAG) . --push)
 	@echo "remove builder instance $1"
 	-(docker buildx rm $1)
+else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), linux/arm64 linux/amd64))
+	(cd ../build/docker/$1; docker build ${NO_CACHE} --platform ${TARGET_ARCH} --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} --build-arg SPARK_VERSION=${SPARK_VERSION} -t $(HUB_ORG)/$1:$(TAG) .)
+	@-docker images $(HUB_ORG)/$1:$(TAG)
 else
 	(cd ../build/docker/$1; docker build ${NO_CACHE} --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} --build-arg SPARK_VERSION=${SPARK_VERSION} -t $(HUB_ORG)/$1:$(TAG) .)
 	@-docker images $(HUB_ORG)/$1:$(TAG)

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -2,8 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 
 .PHONY: help clean clean-images clean-enterprise-gateway clean-enterprise-gateway-demo clean-demo-base \
-		clean-kernel-images clean-py clean-tf-py clean-tf-gpu-py clean-r clean-spark-r clean-scala toree-launcher \
-		kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker clean-kernel-image-puller
+    clean-kernel-images clean-py clean-tf-py clean-tf-gpu-py clean-r clean-spark-r clean-scala toree-launcher \
+    kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker clean-kernel-image-puller
 
 SA?=source activate
 ENV:=enterprise-gateway-dev
@@ -47,8 +47,8 @@ TOREE_LAUNCHER_FILES:=$(shell find kernel-launchers/scala/toree-launcher/src -ty
 	@mkdir -p ../build/kernelspecs
 		# Seed the build tree with initial files
 	cp -r kernelspecs ../build
-		# Distribute language and config-sensitive files.
-		# On-prem kernelspecs get launcher files in the kernelspec hierarchy
+    # Distribute language and config-sensitive files.
+    # On-prem kernelspecs get launcher files in the kernelspec hierarchy
 	@echo ../build/kernelspecs/python_distributed | xargs -t -n 1 cp -r kernel-launchers/python/scripts
 	@echo ../build/kernelspecs/dask_python_* | xargs -t -n 1 cp -r kernel-launchers/python/scripts
 	@echo ../build/kernelspecs/spark_python_{conductor*,yarn*} | xargs -t -n 1 cp -r kernel-launchers/python/scripts
@@ -59,12 +59,12 @@ TOREE_LAUNCHER_FILES:=$(shell find kernel-launchers/scala/toree-launcher/src -ty
 	@echo ../build/kernelspecs/spark_{python,R,scala}_kubernetes | xargs -t -n 1 cp -r kernel-launchers/kubernetes/*
 	@echo ../build/kernelspecs/{python,R,scala,python_tf,python_tf_gpu}_docker | xargs -t -n 1 cp -r kernel-launchers/docker/*
 	@echo ../build/kernelspecs/spark_python_operator | xargs -t -n 1 cp -r kernel-launchers/operators/*
-				# Populate kernel resources.  Because tensorflow is also python, it should be last.
+        # Populate kernel resources.  Because tensorflow is also python, it should be last.
 	@echo ../build/kernelspecs/*R* | xargs -t -n 1 cp -r kernel-resources/ir/*
 	@echo ../build/kernelspecs/*scala* | xargs -t -n 1 cp -r kernel-resources/apache_toree/*
 	@echo ../build/kernelspecs/*python* | xargs -t -n 1 cp -r kernel-resources/python/*
 	@echo ../build/kernelspecs/*tf* | xargs -t -n 1 cp -r kernel-resources/tensorflow/*
-		# Perform the copy again to enable local, per-kernel, overrides
+    # Perform the copy again to enable local, per-kernel, overrides
 	cp -r kernelspecs ../build
 	@(cd ../build/kernelspecs; find . -name 'kernel.json' -print0 | xargs -0 sed -i.bak "s/VERSION/$(TAG)/g"; find . -name *.bak -print0 | xargs -0 rm -f)
 	@mkdir -p ../dist


### PR DESCRIPTION
This pull is pretty simple, it adds a TARGET_ARCH variable to makefile and enable users to do something like:

```bash
make enterprise-gateway TARGET_ARCH='linux/amd64'
```

With the growing number of client machines like macbook m1, this can help users who do not want to build for multiple architecture but still can specify their desired architecture to work perfectly without having to change the source code. I have run into situation where docker build on macbook would just build an ARM version so the cloud linux amd 64 machine cannot run the executable file. 



![1067](https://user-images.githubusercontent.com/15828926/210040494-53f9d686-19e1-4f40-abce-9857f10f08c4.png)


---

![97991](https://user-images.githubusercontent.com/15828926/210040697-e8e840db-419e-43ea-aaa8-fff881bf564a.png)
