### PR TITLE
Start EG in demo-image to inherit PYSPARK_PYTHON env

### DIFF
--- a/etc/docker/enterprise-gateway-demo/start-enterprise-gateway.sh.template
+++ b/etc/docker/enterprise-gateway-demo/start-enterprise-gateway.sh.template
@@ -21,6 +21,7 @@ echo "Starting Jupyter Enterprise Gateway..."
 
 jupyter enterprisegateway \
 	--log-level=${EG_LOG_LEVEL} \
+	--EnterpriseGatewayApp.inherited_envs=PYSPARK_PYTHON \
 	--MappingKernelManager.cull_idle_timeout=${EG_CULL_IDLE_TIMEOUT} \
 	--MappingKernelManager.cull_interval=30 \
 	--MappingKernelManager.cull_connected=${EG_CULL_CONNECTED} 2>&1 | tee /usr/local/share/jupyter/enterprise-gateway.log


### PR DESCRIPTION
I suspect the [change to not unconditionally inherit the value of env `PATH`](https://github.com/jupyter-server/enterprise_gateway/pull/1225) has side-affected the CI test `test_r_kernel.py::TestRKernelClient` because it can no longer find the `python` command (based on troubleshooting the issue).

Rather than flow `PATH` via the `inherited_envs` configurable (as suggested [here](https://github.com/jupyter-server/enterprise_gateway/pull/1225#issuecomment-1357919983)), this change updates the start script of the `enterprise-gateway-demo` image to add the value of env `PYSPARK_PYTHON` via `inherited_envs` since that's the minimal value necessary to get the `TestRKernelClient` test passing.  It also serves as an example of how to propagate a value from the EG process to kernels.