### PR TITLE
Update python interrupt test

### DIFF
--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -52,10 +52,10 @@ class PythonKernelBaseTestCase(TestBase):
 
         # Build the code list to interrupt, in this case, its a sleep call.
         interrupted_code = list()
-        interrupted_code.append("i = 2\n")
-        interrupted_code.append("while i > 0:\n")
-        interrupted_code.append("    i *= i\n")
-        interrupted_code.append("    print(i)\n")
+        interrupted_code.append("import time\n")
+        interrupted_code.append("print('begin')\n")
+        interrupted_code.append("time.sleep(60)\n")
+        interrupted_code.append("print('end')\n")
 
         interrupted_result = self.kernel.execute(interrupted_code)
 


### PR DESCRIPTION
The python interrupt tests (for all integrations on Yarn) started failing due to string length limits because it was building a string whose length got too long.  Not sure why this just started failing CI but there must have been some kind of update to check that.  This pull request makes the python interrupts more like the Scala and R interrupt tests where a `sleep()` call is getting interrupted.  

(Note that the building of the long string was to generate CPU load for the [PR at the time](https://github.com/jupyter-server/enterprise_gateway/pull/686), which switched the launcher from a thread to a process since a kernel's operation could starve the ability for the thread to perform the interrupt.  Given that we've demonstrated that, I feel it's okay to make these tests like the other two kernels.)