### PR TITLE
Disable healthcheck on kernel-images derived from notebook images

### DIFF
--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -28,5 +28,10 @@ RUN chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chown -R jovyan:users /usr/local/bin/kernel-launchers
 
 USER jovyan
+
 ENV KERNEL_LANGUAGE python
+
+# Disble healthcheck inherited from notebook image
+HEALTHCHECK NONE
+
 CMD /usr/local/bin/bootstrap-kernel.sh

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -24,5 +24,10 @@ RUN chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chown -R jovyan:users /usr/local/bin/kernel-launchers
 
 USER jovyan
+
 ENV KERNEL_LANGUAGE R
+
+# Disble healthcheck inherited from notebook image
+HEALTHCHECK NONE
+
 CMD /usr/local/bin/bootstrap-kernel.sh

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -22,4 +22,7 @@ RUN chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 
 USER jovyan
 
+# Disble healthcheck inherited from notebook image
+HEALTHCHECK NONE
+
 CMD [ "/usr/local/bin/bootstrap-kernel.sh" ]


### PR DESCRIPTION
This pull request _preemptively_ disables the `HEALTHCHECK` command that _may be_ inherited from the [jupyter/docker-stacks](https://github.com/jupyter/docker-stacks) images.  Note that the inherited notebook images do not currently have `HEALTHCHECK` commands as they were added in March of 2022 and we currently base images from January of 2022, but I wanted to get these updates in place in case the base images are updated (thus the italics).

I've confirmed the images are operational (in Kubernetes) and exhibit the expected metadata produced via `docker inspect`:
```json
            "Healthcheck": {
                "Test": [
                    "NONE"
                ]
            },
```

Resolves #1218