### PR TITLE
Update java certs to avoid multi-arch builds to hang

### DIFF
--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -41,7 +41,6 @@ RUN dpkg --purge --force-depends ca-certificates-java \
     less \
     nano \
     ca-certificates \
-    ca-certificates-java \
     libkrb5-dev \
     sudo \
     locales \
@@ -54,9 +53,10 @@ RUN dpkg --purge --force-depends ca-certificates-java \
     software-properties-common \
     openssh-server \
     openssh-client \
- && apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' \
- && apt-get update && apt-get install -yq --no-install-recommends openjdk-8-jdk \
- && rm -rf /var/lib/apt/lists/*
+    && apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' \
+    && apt-get update && apt-get install -yq --no-install-recommends openjdk-8-jre-headless \
+    ca-certificates-java \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN ln -s $(readlink -f /usr/bin/javac | sed "s:/bin/javac::") ${JAVA_HOME}
 

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -31,9 +31,9 @@ ENV SPARK_VER $SPARK_VERSION
 ENV HADOOP_VER 3.3.1
 
 # INSTALL / DOWNLOAD ALL NEEDED PACKAGES
-RUN sudo dpkg --purge --force-depends ca-certificates-java \
- && apt-get update && apt-get -yq dist-upgrade \
- && apt-get install -yq --no-install-recommends \
+RUN dpkg --purge --force-depends ca-certificates-java \
+    && apt-get update && apt-get -yq dist-upgrade \
+    && apt-get install -yq --no-install-recommends \
     wget \
     bzip2 \
     tar \

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -31,7 +31,8 @@ ENV SPARK_VER $SPARK_VERSION
 ENV HADOOP_VER 3.3.1
 
 # INSTALL / DOWNLOAD ALL NEEDED PACKAGES
-RUN apt-get update && apt-get -yq dist-upgrade \
+RUN sudo dpkg --purge --force-depends ca-certificates-java \
+ && apt-get update && apt-get -yq dist-upgrade \
  && apt-get install -yq --no-install-recommends \
     wget \
     bzip2 \
@@ -40,6 +41,7 @@ RUN apt-get update && apt-get -yq dist-upgrade \
     less \
     nano \
     ca-certificates \
+    ca-certificates-java \
     libkrb5-dev \
     sudo \
     locales \

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -41,6 +41,7 @@ RUN dpkg --purge --force-depends ca-certificates-java \
     less \
     nano \
     ca-certificates \
+    ca-certificates-java \
     libkrb5-dev \
     sudo \
     locales \

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -41,7 +41,6 @@ RUN dpkg --purge --force-depends ca-certificates-java \
     less \
     nano \
     ca-certificates \
-    ca-certificates-java \
     libkrb5-dev \
     sudo \
     locales \

--- a/etc/docker/kernel-spark-py/Dockerfile
+++ b/etc/docker/kernel-spark-py/Dockerfile
@@ -15,8 +15,11 @@ ENV PATH $PATH:$SPARK_HOME/bin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -yq --no-install-recommends \
+RUN dpkg --purge --force-depends ca-certificates-java \
+    && apt-get update \
+    && apt-get install -yq --no-install-recommends \
+    ca-certificates \
+    ca-certificates-java \
     openjdk-8-jdk \
     less \
     curl \

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -16,7 +16,7 @@ ENV PATH $PATH:$SPARK_HOME/bin
 
 RUN dpkg --purge --force-depends ca-certificates-java \
     && apt-get update \
-    && apt-get install -yq --no-install-recommends \
+    && apt-get install -y \
     ca-certificates \
     ca-certificates-java \
     openjdk-8-jdk \

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -14,7 +14,11 @@ ENV KERNEL_LANGUAGE=R
 ENV R_LIBS_USER $R_LIBS_USER:${R_HOME}/library:${SPARK_HOME}/R/lib
 ENV PATH $PATH:$SPARK_HOME/bin
 
-RUN apt-get update && apt-get install -y \
+RUN dpkg --purge --force-depends ca-certificates-java \
+    && apt-get update \
+    && apt-get install -yq --no-install-recommends \
+    ca-certificates \
+    ca-certificates-java \
     openjdk-8-jdk \
     libssl-dev
 

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -20,7 +20,8 @@ RUN dpkg --purge --force-depends ca-certificates-java \
     ca-certificates \
     ca-certificates-java \
     openjdk-8-jdk \
-    libssl-dev
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME /usr/lib/jvm/java
 RUN ln -s $(readlink -f /usr/bin/javac | sed "s:/bin/javac::") ${JAVA_HOME}


### PR DESCRIPTION
When building the images for the 3.2.0 release, the multiarch build was hanging and you could see in the image build logs that they were trying to download/install java and never completing those. Google came to the rescue and suggested updating java certs which resolved the issues. 

```
=> [linux/amd64  2/28] RUN dpkg --purge --force-depends ca-certificates-java     && apt-get update && apt-get -yq dist-upgrade     && apt-get install -yq --no-install-recommen  20118.7s
 => => # Setting up libfontconfig1:amd64 (2.13.1-4.2) ...                                                                                                                                 
 => => # Setting up libavahi-client3:amd64 (0.8-5+deb11u1) ...                                                                                                                            
 => => # Setting up libcups2:amd64 (2.3.3op2-3+deb11u2) ...                                                                                                                               
 => => # Setting up ca-certificates-java (20190909) ...                                                                                                                                   
 => => # /bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)                                                                                                        
 => => # head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory      
```

Note that, after building all images, only the three ones updated on this pr had issues related to java certs.