### PR TITLE
Flow envs to spark operator pods

### DIFF
--- a/docs/source/operators/deploy-kubernetes.md
+++ b/docs/source/operators/deploy-kubernetes.md
@@ -22,7 +22,7 @@ Enterprise Gateway deployments use the [elyra/enterprise-gateway](https://hub.do
 
 When deployed within a [spark-on-kubernetes](https://spark.apache.org/docs/latest/running-on-kubernetes.html) cluster, Enterprise Gateway can easily support cluster-managed kernels distributed across the cluster. Enterprise Gateway will also provide standalone (i.e., _vanilla_) kernel invocation (where spark contexts are not automatically created) which also benefits from their distribution across the cluster.
 
-```{note}
+````{note}
 If you plan to use kernel specifications derived from the `spark_python_operator` sample, ensure that the
 [Kubernetes Operator for Apache Spark is installed](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator#installation)
 in your Kubernetes cluster.
@@ -32,7 +32,7 @@ To ensure the proper flow of environment variables to your spark application, ma
 webhook server is enabled when deploying the helm chart:
 
 `helm install my-release spark-operator/spark-operator --namespace spark-operator --set webhook.enable=true`
-```
+````
 
 We are using helm templates to manage Kubernetes resource configurations, which allows an end-user to easily customize their Enterprise Gateway deployment.
 

--- a/docs/source/operators/deploy-kubernetes.md
+++ b/docs/source/operators/deploy-kubernetes.md
@@ -23,7 +23,15 @@ Enterprise Gateway deployments use the [elyra/enterprise-gateway](https://hub.do
 When deployed within a [spark-on-kubernetes](https://spark.apache.org/docs/latest/running-on-kubernetes.html) cluster, Enterprise Gateway can easily support cluster-managed kernels distributed across the cluster. Enterprise Gateway will also provide standalone (i.e., _vanilla_) kernel invocation (where spark contexts are not automatically created) which also benefits from their distribution across the cluster.
 
 ```{note}
-If you plan to use kernel specifications derived from the `spark_python_operator` sample, ensure that the [Kubernetes Operator for Apache Spark is installed](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator#installation) in your Kubernetes cluster.
+If you plan to use kernel specifications derived from the `spark_python_operator` sample, ensure that the
+[Kubernetes Operator for Apache Spark is installed](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator#installation)
+in your Kubernetes cluster.
+
+```{tip}
+To ensure the proper flow of environment variables to your spark application, make sure the
+webhook server is enabled when deploying the helm chart:
+
+`helm install my-release spark-operator/spark-operator --namespace spark-operator --set webhook.enable=true`
 ```
 
 We are using helm templates to manage Kubernetes resource configurations, which allows an end-user to easily customize their Enterprise Gateway deployment.

--- a/etc/kernel-launchers/operators/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/operators/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -20,6 +20,12 @@ spec:
     - "--public-key"
     - "{{ eg_public_key }}"
   driver:
+    env:
+# Add any custom envs here that aren't already configured for the kernel's environment
+# Note: For envs to flow to the pods, the webhook server must be enabled during deployment
+# e.g., helm install my-release spark-operator/spark-operator --namespace spark-operator --set webhook.enable=true
+#    - name: MY_DRIVER_ENV
+#      value: "my_driver_value"
     serviceAccount: "{{ kernel_service_account_name }}"
     labels:
       kernel_id: "{{ kernel_id }}"
@@ -29,6 +35,12 @@ spec:
     coreLimit: 1000m
     memory: 1g
   executor:
+    env:
+# Add any custom envs here that aren't already configured for the kernel's environment
+# Note: For envs to flow to the pods, the webhook server must be enabled during deployment
+# e.g., helm install my-release spark-operator/spark-operator --namespace spark-operator --set webhook.enable=true
+#    - name: MY_EXECUTOR_ENV
+#      value: "my_executor_value"
     labels:
       kernel_id: "{{ kernel_id }}"
       app: enterprise-gateway


### PR DESCRIPTION
This pull request applies similar logic for flowing envs to spark-operator pods to that used by regular pods.  The envs are added into the container's specification if the CRD's resource group is `sparkoperator.k8s.io`.  Both the _driver_ and _executor_ envs are updated.  If the group is not `sparkoperator.k8s.io`, nothing occurs since, presumably, the location of the env stanza will be different.

While troubleshooting this change, it was discovered that the spark operator's `webhook server` must be enabled for envs to be transferred.  As a result, both the deployment document and the spark application jinja template have been updated with the appropriate `helm` command.

Since the doc update uses a nested Note/Tip box that looks a bit strange in the raw text, I'm including a screenshot here:
![Screenshot 2023-01-17 at 2 50 30 PM](https://user-images.githubusercontent.com/22599560/213031243-9bca3860-e16a-42db-aa1e-40045f559dac.png)

I have confirmed that envs listed in the `kernel.json`'s `env` stanza are present within the notebook, as are **all** `KERNEL_`-prefixed envs.

Resolves #1224