### PR TITLE
Dump Kubernetes YAML/CRD on kernel startup fails

### DIFF
--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -225,7 +225,7 @@ def launch_kubernetes_kernel(  # noqa
                     f"kernel launch terminating!"
                 )
         else:
-            print(f"ERROR processing Kubernetes yaml file - kernel launch terminating!")
+            print("ERROR processing Kubernetes yaml file - kernel launch terminating!")
             print(k8s_yaml)
             sys.exit(
                 f"ERROR - Unknown Kubernetes object '{k8s_obj}' found in yaml file - kernel launch terminating!"

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -225,6 +225,8 @@ def launch_kubernetes_kernel(  # noqa
                     f"kernel launch terminating!"
                 )
         else:
+            print(f"ERROR processing Kubernetes yaml file - kernel launch terminating!")
+            print(k8s_yaml)
             sys.exit(
                 f"ERROR - Unknown Kubernetes object '{k8s_obj}' found in yaml file - kernel launch terminating!"
             )

--- a/etc/kernel-launchers/operators/scripts/launch_custom_resource.py
+++ b/etc/kernel-launchers/operators/scripts/launch_custom_resource.py
@@ -98,7 +98,7 @@ def launch_custom_resource_kernel(
                 "instructions, then retry the operation.\n"
             )
         else:
-            print(f"ERROR processing Kubernetes Operator CRD - kernel launch terminating!")
+            print("ERROR processing Kubernetes Operator CRD - kernel launch terminating!")
             print(custom_resource_yaml)
         raise ex
 

--- a/etc/kernel-launchers/operators/scripts/launch_custom_resource.py
+++ b/etc/kernel-launchers/operators/scripts/launch_custom_resource.py
@@ -97,6 +97,9 @@ def launch_custom_resource_kernel(
                 "See 'https://github.com/GoogleCloudPlatform/spark-on-k8s-operator#installation' for "
                 "instructions, then retry the operation.\n"
             )
+        else:
+            print(f"ERROR processing Kubernetes Operator CRD - kernel launch terminating!")
+            print(custom_resource_yaml)
         raise ex
 
 


### PR DESCRIPTION
A submitted kernel can fail due to the malformation of 
YAML/CRD contents and in this case, dumping the 
files in the log can help with problem determination.