### PR TITLE
A few small changes to gateway client

### DIFF
--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -119,9 +119,13 @@ class KernelClient:
         self.log = logger
         self.log.debug(f"Initializing kernel client ({kernel_id}) to {self.kernel_ws_api_endpoint}")
 
-        self.kernel_socket = websocket.create_connection(
-            self.kernel_ws_api_endpoint, timeout=timeout, enable_multithread=True
-        )
+        try:
+            self.kernel_socket = websocket.create_connection(
+                f"{ws_api_endpoint}/{kernel_id}/channels", timeout=timeout, enable_multithread=True
+            )
+        except Exception as e:
+            self.log.error(e)
+            self.shutdown()
 
         self.response_queues = {}
 

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -41,10 +41,13 @@ class GatewayClient:
         self.log.setLevel(log_level)
 
     def start_kernel(
-        self, kernelspec_name, extra_env, username=DEFAULT_USERNAME, timeout=REQUEST_TIMEOUT
+        self, kernelspec_name, username=DEFAULT_USERNAME, timeout=REQUEST_TIMEOUT, extra_env=None
     ):
         """Start a kernel."""
         self.log.info(f"Starting a {kernelspec_name} kernel ....")
+
+        if extra_env is None:
+            extra_env = {}
 
         env = {
             "KERNEL_USERNAME": username,

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -41,8 +41,8 @@ class GatewayClient:
         self.log.info(f"Starting a {kernelspec_name} kernel ....")
         
         env = {
-                "KERNEL_USERNAME": username,
-                "KERNEL_LAUNCH_TIMEOUT": GatewayClient.KERNEL_LAUNCH_TIMEOUT,
+            "KERNEL_USERNAME": username,
+            "KERNEL_LAUNCH_TIMEOUT": GatewayClient.KERNEL_LAUNCH_TIMEOUT,
         }
         env.update(extra_env)
         

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -31,12 +31,18 @@ class GatewayClient:
 
     def __init__(self, host=DEFAULT_GATEWAY_HOST, use_secure_connection=False):
         """Initialize the client."""
-        self.http_api_endpoint = f"https://{host}/api/kernels" if use_secure_connection else f"http://{host}/api/kernels"
-        self.ws_api_endpoint = f"wss://{host}/api/kernels" if use_secure_connection else f"wss://{host}/api/kernels"
+        self.http_api_endpoint = (
+            f"https://{host}/api/kernels" if use_secure_connection else f"http://{host}/api/kernels"
+        )
+        self.ws_api_endpoint = (
+            f"wss://{host}/api/kernels" if use_secure_connection else f"wss://{host}/api/kernels"
+        )
         self.log = logging.getLogger("GatewayClient")
         self.log.setLevel(log_level)
 
-    def start_kernel(self, kernelspec_name, extra_env, username=DEFAULT_USERNAME, timeout=REQUEST_TIMEOUT):
+    def start_kernel(
+        self, kernelspec_name, extra_env, username=DEFAULT_USERNAME, timeout=REQUEST_TIMEOUT
+    ):
         """Start a kernel."""
         self.log.info(f"Starting a {kernelspec_name} kernel ....")
         

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -35,7 +35,7 @@ class GatewayClient:
             f"https://{host}/api/kernels" if use_secure_connection else f"http://{host}/api/kernels"
         )
         self.ws_api_endpoint = (
-            f"wss://{host}/api/kernels" if use_secure_connection else f"wss://{host}/api/kernels"
+            f"wss://{host}/api/kernels" if use_secure_connection else f"ws://{host}/api/kernels"
         )
         self.log = logging.getLogger("GatewayClient")
         self.log.setLevel(log_level)

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -36,7 +36,7 @@ class GatewayClient:
         self.log = logging.getLogger("GatewayClient")
         self.log.setLevel(log_level)
 
-    def start_kernel(self, kernelspec_name, username=DEFAULT_USERNAME, timeout=REQUEST_TIMEOUT, extra_env={}):
+    def start_kernel(self, kernelspec_name, extra_env, username=DEFAULT_USERNAME, timeout=REQUEST_TIMEOUT):
         """Start a kernel."""
         self.log.info(f"Starting a {kernelspec_name} kernel ....")
         

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -117,7 +117,7 @@ class KernelClient:
         self.kernel_ws_api_endpoint = f"{ws_api_endpoint}/{kernel_id}/channels"
         self.kernel_id = kernel_id
         self.log = logger
-        self.log.info(f"Initializing kernel client ({kernel_id}) to {self.kernel_ws_api_endpoint}")
+        self.log.debug(f"Initializing kernel client ({kernel_id}) to {self.kernel_ws_api_endpoint}")
 
         self.kernel_socket = websocket.create_connection(
             self.kernel_ws_api_endpoint, timeout=timeout, enable_multithread=True

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -45,13 +45,13 @@ class GatewayClient:
     ):
         """Start a kernel."""
         self.log.info(f"Starting a {kernelspec_name} kernel ....")
-        
+
         env = {
             "KERNEL_USERNAME": username,
             "KERNEL_LAUNCH_TIMEOUT": GatewayClient.KERNEL_LAUNCH_TIMEOUT,
         }
         env.update(extra_env)
-        
+
         json_data = {
             "name": kernelspec_name,
             "env": env,

--- a/enterprise_gateway/itests/test_authorization.py
+++ b/enterprise_gateway/itests/test_authorization.py
@@ -25,8 +25,9 @@ class TestAuthorization(unittest.TestCase):
         kernel = None
         try:
             kernel = self.gateway_client.start_kernel(TestAuthorization.KERNELSPEC, username="bob")
-            result = kernel.execute("print('The cow jumped over the moon.')")
+            result, has_error = kernel.execute("print('The cow jumped over the moon.')")
             self.assertEqual(result, "The cow jumped over the moon.\n")
+            self.assertEqual(has_error, False)
         finally:
             if kernel:
                 self.gateway_client.shutdown_kernel(kernel)

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -12,7 +12,9 @@ class PythonKernelBaseTestCase(TestBase):
     """
 
     def test_get_hostname(self):
-        result, has_error = self.kernel.execute("import subprocess; subprocess.check_output(['hostname'])")
+        result, has_error = self.kernel.execute(
+            "import subprocess; subprocess.check_output(['hostname'])"
+        )
         self.assertEqual(has_error, False)
         self.assertRegex(result, self.get_expected_hostname())
 
@@ -27,7 +29,7 @@ class PythonKernelBaseTestCase(TestBase):
         # 3. Attempt to increment the variable, verify an error was received (due to undefined variable)
 
         self.kernel.execute("x = 123")
-        original_value, has_error = int(self.kernel.execute("print(x)"))  # This will only return the value.
+        original_value, has_error = int(self.kernel.execute("print(x)"))
         self.assertEqual(original_value, 123)
         self.assertEqual(has_error, False)
 
@@ -45,7 +47,7 @@ class PythonKernelBaseTestCase(TestBase):
         # 5. Attempt to increment the variable, verify expected result.
 
         self.kernel.execute("x = 123")
-        original_value, has_error = int(self.kernel.execute("print(x)"))  # This will only return the value.
+        original_value, has_error = int(self.kernel.execute("print(x)"))
         self.assertEqual(original_value, 123)
         self.assertEqual(has_error, True)
 
@@ -71,7 +73,7 @@ class PythonKernelBaseTestCase(TestBase):
 
         # Increment the pre-interrupt variable and ensure its value is correct
         self.kernel.execute("y = x + 1")
-        interrupted_value, has_error = self.kernel.execute("print(y)") # This will only return the value.
+        interrupted_value, has_error = self.kernel.execute("print(y)")
         self.assertEqual(int(interrupted_value), 124)
         self.assertEqual(has_error, False)
 

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -49,7 +49,7 @@ class PythonKernelBaseTestCase(TestBase):
         self.kernel.execute("x = 123")
         original_value, has_error = self.kernel.execute("print(x)")
         self.assertEqual(int(original_value), 123)
-        self.assertEqual(has_error, True)
+        self.assertEqual(has_error, False)
 
         # Start a thread that performs the interrupt.  This thread must wait long enough to issue
         # the next cell execution.

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -12,11 +12,13 @@ class PythonKernelBaseTestCase(TestBase):
     """
 
     def test_get_hostname(self):
-        result = self.kernel.execute("import subprocess; subprocess.check_output(['hostname'])")
+        result, has_error = self.kernel.execute("import subprocess; subprocess.check_output(['hostname'])")
+        self.assertEqual(has_error, False)
         self.assertRegex(result, self.get_expected_hostname())
 
     def test_hello_world(self):
-        result = self.kernel.execute("print('Hello World')")
+        result, has_error = self.kernel.execute("print('Hello World')")
+        self.assertEqual(has_error, False)
         self.assertRegex(result, "Hello World")
 
     def test_restart(self):
@@ -25,13 +27,15 @@ class PythonKernelBaseTestCase(TestBase):
         # 3. Attempt to increment the variable, verify an error was received (due to undefined variable)
 
         self.kernel.execute("x = 123")
-        original_value = int(self.kernel.execute("print(x)"))  # This will only return the value.
+        original_value, has_error = int(self.kernel.execute("print(x)"))  # This will only return the value.
         self.assertEqual(original_value, 123)
+        self.assertEqual(has_error, False)
 
         self.assertTrue(self.kernel.restart())
 
-        error_result = self.kernel.execute("y = x + 1")
+        error_result, has_error = self.kernel.execute("y = x + 1")
         self.assertRegex(error_result, "NameError")
+        self.assertEqual(has_error, True)
 
     def test_interrupt(self):
         # 1. Set a variable to a known value.
@@ -41,8 +45,9 @@ class PythonKernelBaseTestCase(TestBase):
         # 5. Attempt to increment the variable, verify expected result.
 
         self.kernel.execute("x = 123")
-        original_value = int(self.kernel.execute("print(x)"))  # This will only return the value.
+        original_value, has_error = int(self.kernel.execute("print(x)"))  # This will only return the value.
         self.assertEqual(original_value, 123)
+        self.assertEqual(has_error, True)
 
         # Start a thread that performs the interrupt.  This thread must wait long enough to issue
         # the next cell execution.
@@ -55,18 +60,20 @@ class PythonKernelBaseTestCase(TestBase):
         interrupted_code.append("time.sleep(60)\n")
         interrupted_code.append("print('end')\n")
 
-        interrupted_result = self.kernel.execute(interrupted_code)
+        interrupted_result, has_error = self.kernel.execute(interrupted_code)
 
         # Ensure the result indicates an interrupt occurred
         self.assertRegex(interrupted_result, "KeyboardInterrupt")
+        self.assertEqual(has_error, True)
 
         # Wait for thread to terminate - should be terminated already
         self.kernel.terminate_interrupt_thread()
 
         # Increment the pre-interrupt variable and ensure its value is correct
         self.kernel.execute("y = x + 1")
-        interrupted_value = int(self.kernel.execute("print(y)"))  # This will only return the value.
-        self.assertEqual(interrupted_value, 124)
+        interrupted_value, has_error = self.kernel.execute("print(y)") # This will only return the value.
+        self.assertEqual(int(interrupted_value), 124)
+        self.assertEqual(has_error, False)
 
     def test_scope(self):
         # Ensure global variable is accessible in function.
@@ -78,8 +85,9 @@ class PythonKernelBaseTestCase(TestBase):
         scope_code.append("    return a\n")
         scope_code.append("\n")
         scope_code.append("scope()\n")
-        result = self.kernel.execute(scope_code)
+        result, has_error = self.kernel.execute(scope_code)
         self.assertEqual(result, str(42))
+        self.assertEqual(has_error, False)
 
 
 class PythonKernelBaseSparkTestCase(PythonKernelBaseTestCase):
@@ -88,20 +96,24 @@ class PythonKernelBaseSparkTestCase(PythonKernelBaseTestCase):
     """
 
     def test_get_application_id(self):
-        result = self.kernel.execute("sc.getConf().get('spark.app.id')")
+        result, has_error = self.kernel.execute("sc.getConf().get('spark.app.id')")
         self.assertRegex(result, self.get_expected_application_id())
+        self.assertEqual(has_error, False)
 
     def test_get_deploy_mode(self):
-        result = self.kernel.execute("sc.getConf().get('spark.submit.deployMode')")
+        result, has_error = self.kernel.execute("sc.getConf().get('spark.submit.deployMode')")
         self.assertRegex(result, self.get_expected_deploy_mode())
+        self.assertEqual(has_error, False)
 
     def test_get_resource_manager(self):
-        result = self.kernel.execute("sc.getConf().get('spark.master')")
+        result, has_error = self.kernel.execute("sc.getConf().get('spark.master')")
         self.assertRegex(result, self.get_expected_spark_master())
+        self.assertEqual(has_error, False)
 
     def test_get_spark_version(self):
-        result = self.kernel.execute("sc.version")
+        result, has_error = self.kernel.execute("sc.version")
         self.assertRegex(result, self.get_expected_spark_version())
+        self.assertEqual(has_error, False)
 
     def test_run_pi_example(self):
         # Build the example code...
@@ -116,8 +128,9 @@ class PythonKernelBaseSparkTestCase(PythonKernelBaseTestCase):
         pi_code.append("    return 1 if x ** 2 + y ** 2 <= 1 else 0\n")
         pi_code.append("count = sc.parallelize(range(1, n + 1), partitions).map(f).reduce(add)\n")
         pi_code.append('print("Pi is roughly %f" % (4.0 * count / n))\n')
-        result = self.kernel.execute(pi_code)
+        result, has_error = self.kernel.execute(pi_code)
         self.assertRegex(result, "Pi is roughly 3.14*")
+        self.assertEqual(has_error, False)
 
 
 class TestPythonKernelLocal(unittest.TestCase, PythonKernelBaseTestCase):

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -29,8 +29,8 @@ class PythonKernelBaseTestCase(TestBase):
         # 3. Attempt to increment the variable, verify an error was received (due to undefined variable)
 
         self.kernel.execute("x = 123")
-        original_value, has_error = int(self.kernel.execute("print(x)"))
-        self.assertEqual(original_value, 123)
+        original_value, has_error = self.kernel.execute("print(x)")
+        self.assertEqual(int(original_value), 123)
         self.assertEqual(has_error, False)
 
         self.assertTrue(self.kernel.restart())
@@ -47,8 +47,8 @@ class PythonKernelBaseTestCase(TestBase):
         # 5. Attempt to increment the variable, verify expected result.
 
         self.kernel.execute("x = 123")
-        original_value, has_error = int(self.kernel.execute("print(x)"))
-        self.assertEqual(original_value, 123)
+        original_value, has_error = self.kernel.execute("print(x)")
+        self.assertEqual(int(original_value), 123)
         self.assertEqual(has_error, True)
 
         # Start a thread that performs the interrupt.  This thread must wait long enough to issue

--- a/enterprise_gateway/itests/test_r_kernel.py
+++ b/enterprise_gateway/itests/test_r_kernel.py
@@ -12,12 +12,14 @@ class RKernelBaseTestCase(TestBase):
     """
 
     def test_get_hostname(self):
-        result = self.kernel.execute('system("hostname", intern=TRUE)')
+        result, has_error = self.kernel.execute('system("hostname", intern=TRUE)')
         self.assertRegex(result, self.get_expected_hostname())
+        self.assertEqual(has_error, False)
 
     def test_hello_world(self):
-        result = self.kernel.execute('print("Hello World", quote = FALSE)')
+        result, has_error = self.kernel.execute('print("Hello World", quote = FALSE)')
         self.assertRegex(result, "Hello World")
+        self.assertEqual(has_error, False)
 
     def test_restart(self):
         # 1. Set a variable to a known value.
@@ -25,15 +27,15 @@ class RKernelBaseTestCase(TestBase):
         # 3. Attempt to increment the variable, verify an error was received (due to undefined variable)
 
         self.kernel.execute("x = 123")
-        original_value = int(
-            self.kernel.execute("write(x,stdout())")
-        )  # This will only return the value.
-        self.assertEqual(original_value, 123)
+        original_value, has_error = self.kernel.execute("write(x,stdout())")
+        self.assertEqual(int(original_value), 123)
+        self.assertEqual(has_error, False)
 
         self.assertTrue(self.kernel.restart())
 
-        error_result = self.kernel.execute("y = x + 1")
+        error_result, has_error = self.kernel.execute("y = x + 1")
         self.assertRegex(error_result, "Error in eval")
+        self.assertEqual(has_error, True)
 
     def test_interrupt(self):
         # 1. Set a variable to a known value.
@@ -43,10 +45,9 @@ class RKernelBaseTestCase(TestBase):
         # 5. Attempt to increment the variable, verify expected result.
 
         self.kernel.execute("x = 123")
-        original_value = int(
-            self.kernel.execute("write(x,stdout())")
-        )  # This will only return the value.
-        self.assertEqual(original_value, 123)
+        original_value, has_error = self.kernel.execute("write(x,stdout())")
+        self.assertEqual(int(original_value), 123)
+        self.assertEqual(has_error, False)
 
         # Start a thread that performs the interrupt.  This thread must wait long enough to issue
         # the next cell execution.
@@ -57,20 +58,20 @@ class RKernelBaseTestCase(TestBase):
         interrupted_code.append('write("begin",stdout())\n')
         interrupted_code.append("Sys.sleep(30)\n")
         interrupted_code.append('write("end",stdout())\n')
-        interrupted_result = self.kernel.execute(interrupted_code)
+        interrupted_result, has_error = self.kernel.execute(interrupted_code)
 
         # Ensure the result indicates an interrupt occurred
         self.assertEqual(interrupted_result.strip(), "begin")
+        self.assertEqual(has_error, False)
 
         # Wait for thread to terminate - should be terminated already
         self.kernel.terminate_interrupt_thread()
 
         # Increment the pre-interrupt variable and ensure its value is correct
         self.kernel.execute("y = x + 1")
-        interrupted_value = int(
-            self.kernel.execute("write(y,stdout())")
-        )  # This will only return the value.
-        self.assertEqual(interrupted_value, 124)
+        interrupted_value, has_error = self.kernel.execute("write(y,stdout())")
+        self.assertEqual(int(interrupted_value), 124)
+        self.assertEqual(has_error, False)
 
 
 class RKernelBaseSparkTestCase(RKernelBaseTestCase):
@@ -79,22 +80,26 @@ class RKernelBaseSparkTestCase(RKernelBaseTestCase):
     """
 
     def test_get_application_id(self):
-        result = self.kernel.execute(
+        result, has_error = self.kernel.execute(
             'SparkR:::callJMethod(SparkR:::callJMethod(sc, "sc"), "applicationId")'
         )
         self.assertRegex(result, self.get_expected_application_id())
+        self.assertEqual(has_error, False)
 
     def test_get_spark_version(self):
-        result = self.kernel.execute("sparkR.version()")
+        result, has_error = self.kernel.execute("sparkR.version()")
         self.assertRegex(result, self.get_expected_spark_version())
+        self.assertEqual(has_error, False)
 
     def test_get_resource_manager(self):
-        result = self.kernel.execute('unlist(sparkR.conf("spark.master"))')
+        result, has_error = self.kernel.execute('unlist(sparkR.conf("spark.master"))')
         self.assertRegex(result, self.get_expected_spark_master())
+        self.assertEqual(has_error, False)
 
     def test_get_deploy_mode(self):
-        result = self.kernel.execute('unlist(sparkR.conf("spark.submit.deployMode"))')
+        result, has_error = self.kernel.execute('unlist(sparkR.conf("spark.submit.deployMode"))')
         self.assertRegex(result, self.get_expected_deploy_mode())
+        self.assertEqual(has_error, False)
 
 
 class TestRKernelLocal(unittest.TestCase, RKernelBaseTestCase):

--- a/enterprise_gateway/itests/test_scala_kernel.py
+++ b/enterprise_gateway/itests/test_scala_kernel.py
@@ -12,16 +12,18 @@ class ScalaKernelBaseTestCase(TestBase):
     """
 
     def test_get_hostname(self):
-        result = self.kernel.execute(
+        result, has_error = self.kernel.execute(
             "import java.net._; \
                                       val localhost: InetAddress = InetAddress.getLocalHost; \
                                       val localIpAddress: String = localhost.getHostName"
         )
         self.assertRegex(result, self.get_expected_hostname())
+        self.assertEqual(has_error, False)
 
     def test_hello_world(self):
-        result = self.kernel.execute('println("Hello World")')
+        result, has_error = self.kernel.execute('println("Hello World")')
         self.assertRegex(result, "Hello World")
+        self.assertEqual(has_error, False)
 
     def test_restart(self):
         # 1. Set a variable to a known value.
@@ -29,13 +31,15 @@ class ScalaKernelBaseTestCase(TestBase):
         # 3. Attempt to increment the variable, verify an error was received (due to undefined variable)
 
         self.kernel.execute("var x = 123")
-        original_value = int(self.kernel.execute("x"))  # This will only return the value.
-        self.assertEqual(original_value, 123)
+        original_value, has_error = self.kernel.execute("x")
+        self.assertEqual(int(original_value), 123)
+        self.assertEqual(has_error, False)
 
         self.assertTrue(self.kernel.restart())
 
-        error_result = self.kernel.execute("var y = x + 1")
+        error_result, has_error = self.kernel.execute("var y = x + 1")
         self.assertRegex(error_result, "not found: value x")
+        self.assertEqual(has_error, True)
 
     def test_interrupt(self):
         # 1. Set a variable to a known value.
@@ -45,8 +49,9 @@ class ScalaKernelBaseTestCase(TestBase):
         # 5. Attempt to increment the variable, verify expected result.
 
         self.kernel.execute("var x = 123")
-        original_value = int(self.kernel.execute("x"))  # This will only return the value.
-        self.assertEqual(original_value, 123)
+        original_value, has_error = self.kernel.execute("x")
+        self.assertEqual(int(original_value), 123)
+        self.assertEqual(has_error, False)
 
         # Start a thread that performs the interrupt.  This thread must wait long enough to issue
         # the next cell execution.
@@ -57,18 +62,20 @@ class ScalaKernelBaseTestCase(TestBase):
         interrupted_code.append('println("begin")\n')
         interrupted_code.append("Thread.sleep(60000)\n")
         interrupted_code.append('println("end")\n')
-        interrupted_result = self.kernel.execute(interrupted_code)
+        interrupted_result, has_error = self.kernel.execute(interrupted_code)
 
         # Ensure the result indicates an interrupt occurred
         self.assertRegex(interrupted_result, "java.lang.InterruptedException")
+        self.assertEqual(has_error, False)
 
         # Wait for thread to terminate - should be terminated already
         self.kernel.terminate_interrupt_thread()
 
         # Increment the pre-interrupt variable and ensure its value is correct
         self.kernel.execute("var y = x + 1")
-        interrupted_value = int(self.kernel.execute("y"))  # This will only return the value.
-        self.assertEqual(interrupted_value, 124)
+        interrupted_value, has_error = self.kernel.execute("y")
+        self.assertEqual(int(interrupted_value), 124)
+        self.assertEqual(has_error, False)
 
 
 class ScalaKernelBaseSparkTestCase(ScalaKernelBaseTestCase):
@@ -77,20 +84,24 @@ class ScalaKernelBaseSparkTestCase(ScalaKernelBaseTestCase):
     """
 
     def test_get_application_id(self):
-        result = self.kernel.execute("sc.applicationId")
+        result, has_error = self.kernel.execute("sc.applicationId")
         self.assertRegex(result, self.get_expected_application_id())
+        self.assertEqual(has_error, False)
 
     def test_get_spark_version(self):
-        result = self.kernel.execute("sc.version")
+        result, has_error = self.kernel.execute("sc.version")
         self.assertRegex(result, self.get_expected_spark_version())
+        self.assertEqual(has_error, False)
 
     def test_get_resource_manager(self):
-        result = self.kernel.execute('sc.getConf.get("spark.master")')
+        result, has_error = self.kernel.execute('sc.getConf.get("spark.master")')
         self.assertRegex(result, self.get_expected_spark_master())
+        self.assertEqual(has_error, False)
 
     def test_get_deploy_mode(self):
-        result = self.kernel.execute('sc.getConf.get("spark.submit.deployMode")')
+        result, has_error = self.kernel.execute('sc.getConf.get("spark.submit.deployMode")')
         self.assertRegex(result, self.get_expected_deploy_mode())
+        self.assertEqual(has_error, False)
 
 
 class TestScalaKernelLocal(unittest.TestCase, ScalaKernelBaseTestCase):

--- a/enterprise_gateway/itests/test_scala_kernel.py
+++ b/enterprise_gateway/itests/test_scala_kernel.py
@@ -66,7 +66,7 @@ class ScalaKernelBaseTestCase(TestBase):
 
         # Ensure the result indicates an interrupt occurred
         self.assertRegex(interrupted_result, "java.lang.InterruptedException")
-        self.assertEqual(has_error, False)
+        self.assertEqual(has_error, True)
 
         # Wait for thread to terminate - should be terminated already
         self.kernel.terminate_interrupt_thread()


### PR DESCRIPTION
I made a few small changes to the gateway client locally that I wanted to contribute back. One big issue I dealt with was with my connection to the websocket and http api endpoints failing, so I think it would be really helpful if in the code there was somehow an indication to use secure endpoints. Additionally, we found that we needed to pass a lot of environment variables, so an extra_env dictionary is helpful if you're calling the gateway client and need to pass, for example, queue-specific environment variables. Additionally, in kernel.execute, we should somehow let whatever's calling that function know whether an error was returned or not. As it stands now, kernel.execute will take an error and convert it to text - but what if for example, we're testing some notebook code - to do that, you would need to know if the kernel got an error when executing a cell or not.

I'm open to any edits/suggestions, these are just changes we had to make locally and think could be helpful for other people testing :)