### PR TITLE
Fix the flow of kernel-class-name option in bootstrap script

### DIFF
--- a/etc/kernel-launchers/bootstrap/bootstrap-kernel.sh
+++ b/etc/kernel-launchers/bootstrap/bootstrap-kernel.sh
@@ -17,9 +17,9 @@ launch_python_kernel() {
 
   if [ -z "${KERNEL_CLASS_NAME}" ]
   then
-    kernel_class_option = ""
+    kernel_class_option=""
   else
-    kernel_class_option = "--kernel_class_name ${KERNEL_CLASS_NAME}"
+    kernel_class_option="--kernel-class-name ${KERNEL_CLASS_NAME}"
   fi
 
 	set -x


### PR DESCRIPTION
This pull request fixes an issue with the value and the assignment syntax being used to populate the `kernel_class_option` variable inside the `bootstrap-kernel.sh` script. This will resolve the flow of `--kernel-class-name` option from the bootstrap script to python kernel launcher in the kernel containers.

Please find more details on the issue [here](https://github.com/jupyter-server/enterprise_gateway/pull/1187#discussion_r1115799809).

Resolves [#1184](https://github.com/jupyter-server/enterprise_gateway/issues/1184)