### PR TITLE
Handle not found exception during remove_kernel

### DIFF
--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -257,9 +257,8 @@ class KernelClient:
             return True
         else:
             self.restarting = False
-            msg = "Unexpected response restarting kernel {}: {}".format(
-                self.kernel_id, response.content
-            )
+            msg = f"Unexpected response restarting kernel {self.kernel_id}: {response.content}"
+            self.log.debug(msg)
             raise RuntimeError(msg)
 
     def get_state(self):

--- a/enterprise_gateway/itests/test_authorization.py
+++ b/enterprise_gateway/itests/test_authorization.py
@@ -10,7 +10,6 @@ class TestAuthorization(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        print(">>>")
 
         # initialize environment
         cls.gateway_client = GatewayClient()

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -325,7 +325,7 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
         """
         try:
             super().remove_kernel(kernel_id)
-        except web.HTTPError:  # this is hint for multiple shutdown request.
+        except KeyError: # this is hint for multiple shutdown request.
             self.log.debug(f"Exception while removing kernel {kernel_id}: kernel not found.")
 
         self.parent.kernel_session_manager.delete_session(kernel_id)

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -325,7 +325,7 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
         """
         try:
             super().remove_kernel(kernel_id)
-        except KeyError: # this is hint for multiple shutdown request.
+        except KeyError:  # this is hint for multiple shutdown request.
             self.log.debug(f"Exception while removing kernel {kernel_id}: kernel not found.")
 
         self.parent.kernel_session_manager.delete_session(kernel_id)

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -325,7 +325,7 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
         """
         try:
             super().remove_kernel(kernel_id)
-        except web.HTTPError: # this is hint for multiple shutdown request.
+        except web.HTTPError:  # this is hint for multiple shutdown request.
             self.log.debug(f"Exception while removing kernel {kernel_id}: kernel not found.")
 
         self.parent.kernel_session_manager.delete_session(kernel_id)

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -250,7 +250,7 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
             await self.wait_for_restart_finish(kernel_id, "shutdown")
         try:
             await super().shutdown_kernel(kernel_id, now, restart)
-        except KeyError as ke:  # this is hit for multiple shutdown request.
+        except KeyError as ke:  # this is hint for multiple shutdown request.
             self.log.exception(f"Exception while shutting down kernel: '{kernel_id}': {ke}")
             raise web.HTTPError(404, "Kernel does not exist: %s" % kernel_id) from None
 
@@ -323,7 +323,11 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
         """
         Removes the kernel associated with `kernel_id` from the internal map and deletes the kernel session.
         """
-        super().remove_kernel(kernel_id)
+        try:
+            super().remove_kernel(kernel_id)
+        except web.HTTPError: # this is hint for multiple shutdown request.
+            self.log.debug(f"Exception while removing kernel {kernel_id}: kernel not found.")
+
         self.parent.kernel_session_manager.delete_session(kernel_id)
 
     def start_kernel_from_session(

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -607,8 +607,6 @@ class RemoteKernelManager(EnterpriseGatewayConfigMixin, AsyncIOLoopKernelManager
             Any options specified here will overwrite those used to launch the
             kernel.
         """
-        if now:  # if auto-restarting (when now is True), indicate we're restarting.
-            self.restarting = True
         kernel_id = self.kernel_id or os.path.basename(self.connection_file).replace(
             "kernel-", ""
         ).replace(".json", "")
@@ -628,6 +626,10 @@ class RemoteKernelManager(EnterpriseGatewayConfigMixin, AsyncIOLoopKernelManager
                 # Use the parent mapping kernel manager so activity monitoring and culling is also shutdown
                 await self.mapping_kernel_manager.shutdown_kernel(kernel_id, now=now)
                 return
+
+        if now:  # if auto-restarting (when now is True), indicate we're restarting.
+            self.restarting = True
+
         await super().restart_kernel(now, **kwargs)
         if isinstance(self.process_proxy, RemoteProcessProxy):  # for remote kernels...
             # Re-establish activity watching...


### PR DESCRIPTION
Enhance the remove_kernel to properly handle not found kernels (key error) to better support duplicate restarts or restart/shutdown use cases. 

Fixes #1261