### PR TITLE
Set language and fix conda env link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,7 +87,7 @@ release = version_ns["__version__"]
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -58,7 +58,7 @@ Some of the more useful commands are listed below.
 Build a Python 3 conda environment that can be used to run
 the Enterprise Gateway server within an IDE. May be necessary prior
 to [debugging Enterprise Gateway](./debug.md) based on your local Python environment.
-See [Conda's Managing environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#managing-environments)
+See [Conda's Managing environments](https://docs.conda.io/projects/conda/en/stable/user-guide/tasks/manage-environments.html#managing-environments)
 for background on environments and why you may find them useful as you develop on Enterprise Gateway.
 
 ```bash


### PR DESCRIPTION
This pull request addresses some docs issues that just came up.

1. An updated version of Sphinx wants a language to be set, so we set the language to `'en'`.
2. The conda docs page for managing environments is no longer working (perhaps temporary) for `latest`, so this changes it to `stable` - where the page can be found.