### PR TITLE
Reset SPARK_VERSION to 3.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ MULTIARCH_BUILD?=
 TARGET_ARCH?=undefined
 
 VERSION?=3.3.0.dev0
-SPARK_VERSION?=3.3.0.dev0
+SPARK_VERSION?=3.2.1
 
 ifeq (dev, $(findstring dev, $(VERSION)))
     TAG:=dev


### PR DESCRIPTION
The version string update code used when creating releases happened to think the `3.2.1` value for `SPARK_VERSION` was the EG release value when, instead, we treat that value as a fixed value.  This value also happens to be the tag for the `elyra/demo-base` docker image - which is the base image for the `elyra/enterprise-gateway-demo` image used to run the integration tests.  Because SPARK_VERSION was no longer reflecting `3.2.1` (but `3.3.0.dev0`) the enterprise-gateway-demo image could not be built - resulting in build failures.  This PR resets the value back to `3.2.1`.

Since we should only have one `3.2.1` release, I don't see this issue being a problem again, so am not bothering to "fix" the release script to avoid its update.