### PR TITLE
Set restart strategy to never for spark operator

### DIFF
--- a/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml.j2
+++ b/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml.j2
@@ -17,6 +17,8 @@ metadata:
     app: enterprise-gateway
     component: kernel
     source: kernel-pod.yaml
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 spec:
   restartPolicy: Never
   serviceAccountName: "{{ kernel_service_account_name }}"

--- a/etc/kernel-launchers/operators/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/operators/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -22,6 +22,8 @@ spec:
     - "--public-key"
     - "{{ eg_public_key }}"
   driver:
+    annotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     env:
 # Add any custom envs here that aren't already configured for the kernel's environment
 # Note: For envs to flow to the pods, the webhook server must be enabled during deployment

--- a/etc/kernel-launchers/operators/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/operators/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -3,6 +3,8 @@ kind: SparkApplication
 metadata:
   name: {{ kernel_resource_name }}
 spec:
+  restartPolicy:
+    type: Never
   type: Python
   pythonVersion: "3"
   sparkVersion: 2.4.5


### PR DESCRIPTION
While reviewing some of the spark operator artifacts 
I noticed it was not setting the Kubernetes 
restart policy to never as the other kernelspecs