### PR TITLE
Fix docker swarm not being to start due to missing inherited function on the latest version

### DIFF
--- a/enterprise_gateway/services/processproxies/docker_swarm.py
+++ b/enterprise_gateway/services/processproxies/docker_swarm.py
@@ -50,6 +50,10 @@ class DockerSwarmProcessProxy(ContainerProcessProxy):
         """Return list of states in lowercase indicating container is starting (includes running)."""
         return {"preparing", "starting", "running"}
 
+    def get_error_states(self) -> set:
+        """Returns the list of error states indicating container is shutting down or receiving error."""
+        return {"failed", "rejected", "complete", "shutdown", "orphaned", "remove"}
+
     def _get_service(self) -> Service:
         # Fetches the service object corresponding to the kernel with a matching label.
         service = None


### PR DESCRIPTION
Since this [commit](https://github.com/jupyter-server/enterprise_gateway/commit/56dffccb7740dd0eeea115cfe7f4233599b6bc1e), starting kernel-py containers via dockerswarm proxy will eventually fail because when get_error_states is reached, NotImplementedError is raise, thus causing a disruption in the scheduling logic

This fix urges to improve that, by specifying error states, taken from https://docs.docker.com/engine/swarm/how-swarm-mode-works/swarm-task-states/ 