### PR TITLE
Updating base image tag to latest available tag

### DIFF
--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_CONTAINER=jupyter/minimal-notebook:2022-01-24
+ARG BASE_CONTAINER=jupyter/minimal-notebook:2023-03-13
 
 FROM $BASE_CONTAINER
 

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/scipy-notebook:2022-01-24
+ARG BASE_CONTAINER=jupyter/scipy-notebook:2023-03-13
 FROM $BASE_CONTAINER
 
 ENV PATH=$PATH:$CONDA_DIR/bin

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/r-notebook:2022-01-24
+ARG BASE_CONTAINER=jupyter/r-notebook:2023-03-13
 FROM $BASE_CONTAINER
 
 RUN conda install --quiet --yes \

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -1,6 +1,6 @@
 # Ubuntu:Bionic
 # TensorFlow 2.4.0
-ARG BASE_CONTAINER=jupyter/tensorflow-notebook:2022-01-24
+ARG BASE_CONTAINER=jupyter/tensorflow-notebook:2023-03-13
 
 FROM $BASE_CONTAINER
 


### PR DESCRIPTION
This PR includes changes to Update the tag of the base image used in the following docker files to the latest available tag.

- kernel-py
- kernel-r
- kernel-tf-py
- enterprise-gateway

Existing tag: 2022-01-24
Updated tag: 2023-03-13

- The existing base image with tag 2022-01-24 was built a year ago with the ubuntu:22.04 as base image built back then. Over time several security vulnerabilities and bugs were fixed and there would be some performance improvements in the ubuntu:22.04 docker image. Updating the base image to the 2023-03-13 tag which in turn uses the latest available ubuntu:22.04 ensures that the latest security patches are applied to the kernel, reducing the risk of potential security issues and taking advantage of improved performance.
- Over time, new versions of dependencies and libraries are released, which may not be compatible with older versions of the base image. Updating the base image ensures that your kernel remains compatible with the latest versions of dependencies and libraries.

Overall, updating the base image in a Dockerfile is important to ensure that your kernel remains secure, stable, and up-to-date with the latest industry standards and best practices