### PR TITLE
Move shutdown kernel code to be within KernelClient

### DIFF
--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -88,7 +88,6 @@ class GatewayClient:
 
         kernel.shutdown()
 
-
 class KernelClient:
     """A kernel client class."""
 

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -109,38 +109,37 @@ class KernelClient:
         self.kernel_id = kernel_id
         self.log = logger
         self.log.debug(f"Initializing kernel client ({kernel_id}) to {self.kernel_ws_api_endpoint}")
+        self.response_queues = {}
+        # startup reader thread
+
+        self.response_reader = Thread(target=self._read_responses)
+        self.response_reader.start()
+        self.interrupt_thread = None
+        self.kernel_socket = None
 
         try:
             self.kernel_socket = websocket.create_connection(
                 f"{ws_api_endpoint}/{kernel_id}/channels", timeout=timeout, enable_multithread=True
             )
         except Exception as e:
-            self.kernel_socket = None
             self.log.error(e)
             self.shutdown()
             raise e
-
-        self.response_queues = {}
-
-        # startup reader thread
-        self.response_reader = Thread(target=self._read_responses)
-        self.response_reader.start()
-        self.interrupt_thread = None
 
     def shutdown(self):
         """Shut down the client."""
         # Terminate thread, close socket and clear queues.
         self.shutting_down = True
 
-        if hasattr(self, 'kernel_socket') and self.kernel_socket:
+        if self.kernel_socket:
             self.kernel_socket.close()
             self.kernel_socket = None
 
-        if hasattr(self, 'response_queues') and self.response_queues:
+        if self.response_queues:
             self.response_queues.clear()
             self.response_queues = None
 
-        if hasattr(self, 'response_reader') and self.response_reader:
+        if self.response_reader:
             self.response_reader.join(timeout=2.0)
             if self.response_reader.is_alive():
                 self.log.warning("Response reader thread is not terminated, continuing...")

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -88,6 +88,7 @@ class GatewayClient:
 
         kernel.shutdown()
 
+
 class KernelClient:
     """A kernel client class."""
 

--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -132,7 +132,7 @@ class KernelClient:
         # Terminate thread, close socket and clear queues.
         self.shutting_down = True
 
-        if not hasattr(self.failed_ws_connection):
+        if not hasattr(self, 'failed_ws_connection'):
             if self.kernel_socket:
                 self.kernel_socket.close()
                 self.kernel_socket = None


### PR DESCRIPTION
The heart of the code that shuts down the kernel (the API request) should be within `KernelClient` itself. This way, when the kernel can shut itself done without the help of `GatewayClient`. This is important in handling the websocket exception, as when we call `kernel.shutdown()`, we actually want to run the API request to shut down the kernel as well. 

Additionally, we should still raise the exception on `KernelClient.__init__()` if the websocket connection fails, as that way `GatewayClient.start_kernel` will error out if the connection to the `KernelClient` isn't working.