### PR TITLE
Switch from conda to venv for development env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ _site/
 # jetbrains ide stuff
 *.iml
 .idea/
+
+# virtual environment
+.venv/

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@
     push-kernel-images push-enterprise-gateway push-kernel-py push-kernel-spark-py push-kernel-r push-kernel-spark-r \
     push-kernel-scala push-kernel-tf-py push-kernel-tf-gpu-py push-kernel-image-puller publish helm-chart
 
-SA?=source activate
-ENV:=enterprise-gateway-dev
+ENV:=.venv
 SHELL:=/bin/bash
 MULTIARCH_BUILD?=
 TARGET_ARCH?=undefined
@@ -42,11 +41,11 @@ help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 env: ## Make a dev environment
-	-conda env create --file requirements.yml --name $(ENV)
-	-conda env config vars set PYTHONPATH=$(PWD) --name $(ENV)
+	-python3 -m venv $(ENV)
+	-$(ENV)/bin/pip install -e .
 
 activate: ## Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
-	@echo "Run \`$(SA) $(ENV)\` to activate the environment."
+	@echo "Run \`source $(ENV)/bin/activate\` to activate the environment."
 
 clean: ## Make a clean source tree
 	-rm -rf dist
@@ -61,8 +60,8 @@ clean: ## Make a clean source tree
 	-make -C docs clean
 	-make -C etc clean
 
-clean-env: ## Remove conda env
-	-conda env remove -n $(ENV) -y
+clean-env: ## Remove virtual environment
+	-rm -rf $(ENV)
 
 lint: ## Check code style
 	@pip install -q -e ".[lint]"

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -58,8 +58,8 @@ Some of the more useful commands are listed below.
 Build a Python 3 virtual environment that can be used to run
 the Enterprise Gateway server within an IDE. May be necessary prior
 to [debugging Enterprise Gateway](./debug.md) based on your local Python environment.
-See Python's [Virtual Environments](https://docs.python.org/3/tutorial/venv.html#virtual-environments-and-packages), 
-and [Installing Packages](https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-from-a-local-src-tree) 
+See Python's [Virtual Environments](https://docs.python.org/3/tutorial/venv.html#virtual-environments-and-packages),
+and [Installing Packages](https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-from-a-local-src-tree)
 documentation pages for background on environments and why you may find them useful as you develop on Enterprise Gateway.
 
 ```bash

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -28,8 +28,8 @@ Enterprise Gateway's build environment is centered around `make` and the corresp
 Entering `make` with no parameters yields the following:
 
 ```
-activate                       Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
-clean-env                      Remove conda env
+activate                       Print instructions to activate the virtualenv (default: .venv)
+clean-env                      Remove virtual env
 clean-images                   Remove docker images (includes kernel-based images)
 clean-kernel-images            Remove kernel-based images
 clean                          Make a clean source tree
@@ -53,19 +53,20 @@ test                           Run unit tests
 
 Some of the more useful commands are listed below.
 
-## Build the conda environment
+## Build the virtual environment
 
-Build a Python 3 conda environment that can be used to run
+Build a Python 3 virtual environment that can be used to run
 the Enterprise Gateway server within an IDE. May be necessary prior
 to [debugging Enterprise Gateway](./debug.md) based on your local Python environment.
-See [Conda's Managing environments](https://docs.conda.io/projects/conda/en/stable/user-guide/tasks/manage-environments.html#managing-environments)
-for background on environments and why you may find them useful as you develop on Enterprise Gateway.
+See Python's [Virtual Environments](https://docs.python.org/3/tutorial/venv.html#virtual-environments-and-packages), 
+and [Installing Packages](https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-from-a-local-src-tree) 
+documentation pages for background on environments and why you may find them useful as you develop on Enterprise Gateway.
 
 ```bash
 make env
 ```
 
-By default, the env built will be named `enterprise-gateway-dev`. To produce a different conda env,
+By default, the env built will be named `.venv`. To produce a different conda env,
 you can specify the name via the `ENV=` parameter.
 
 ```bash


### PR DESCRIPTION
addresses #1294 

Upon doing this, the "happy path" is simpler but overall it feels a little more frail / platform dependent. I'm curious to hear thoughts on that tradeoff or any suggestions people have seen from other repos