### PR TITLE
feat: Add options to mutual authentication

### DIFF
--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -92,11 +92,13 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
                 endpoints.append(self.alt_yarn_endpoint)
 
         if self.yarn_endpoint_security_enabled:
-            from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DEFAULT
+            from requests_kerberos import DEFAULT, OPTIONAL, REQUIRED, HTTPKerberosAuth
 
             auth = HTTPKerberosAuth(
                 mutual_authentication={
-                    "REQUIRED": REQUIRED, "OPTIONAL": OPTIONAL, "DEFAULT": DEFAULT
+                    "REQUIRED": REQUIRED,
+                    "OPTIONAL": OPTIONAL,
+                    "DEFAULT": DEFAULT,
                 }.get(mutual_authentication.upper())
             )
         else:

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -92,13 +92,13 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
                 endpoints.append(self.alt_yarn_endpoint)
 
         if self.yarn_endpoint_security_enabled:
-            from requests_kerberos import DEFAULT, OPTIONAL, REQUIRED, HTTPKerberosAuth
+            from requests_kerberos import DISABLED, OPTIONAL, REQUIRED, HTTPKerberosAuth
 
             auth = HTTPKerberosAuth(
                 mutual_authentication={
                     "REQUIRED": REQUIRED,
                     "OPTIONAL": OPTIONAL,
-                    "DEFAULT": DEFAULT,
+                    "DISABLED": DISABLED,
                 }.get(mutual_authentication.upper())
             )
         else:


### PR DESCRIPTION
### Problem

Currently, Jupyter Server only supports "REQUIRED" mutual authentication on YARN, which may not be sufficient for some use cases. For example, in scenarios where mutual authentication is not required to establish a secure connection between the server and clients, there is no built-in way to configure this in Enterprise Gateway.

### Feature details
I suggest adding an option to the Jupyter Server configuration that allows users optional mutual authentication. When introducing this feature, users can specify with REQUIRED, OPTIONAL or DISABLED. This enhancement would greatly improve user configuration freedom.

### Implementation Details
I included a variable `EG_YARN_MUTUAL_AUTHENTICATION` which users can specify with REQUIRED, OPTIONAL or DISABLED. The value is REQUIRED by defaul