### PR TITLE
[Bug] Fix helm chart logic error

### DIFF
--- a/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
@@ -124,6 +124,7 @@ spec:
       - name: image-kernelspecs
         emptyDir:
           medium: Memory
+  {{- end }}
 
   {{- if .Values.deployment.tolerations }}
       tolerations:
@@ -136,7 +137,5 @@ spec:
   {{- if .Values.deployment.affinity }}
       affinity:
       {{- toYaml .Values.deployment.affinity | nindent 8 }}
-  {{- end }}
-
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This enables successful usage of deployment nodeselectors, tolerations, and affinity. These were previously disabled due to a scoping issue.