### PR TITLE
Better handling of an empty container status in `confirm_remote_startup`

### DIFF
--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -221,7 +221,7 @@ class ContainerProcessProxy(RemoteProcessProxy):
             else:
                 self.log_and_raise(
                     http_status_code=500,
-                    reason="Error starting kernel container; status not available. "
+                    reason="Error starting kernel container; status was not available. "
                            "Perhaps the kernel pod died unexpectedly"
                 )
 


### PR DESCRIPTION
Modified `confirm_remote_startup` method to make handling of empty container status better, so that if a kernel pod dies while still in startup, the startup process will fail and the user won't have to wait for timeout.