### PR TITLE
Docker fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install Python dependencies
+        run: |
+          pip install ".[test]"
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_links: "http://my-gateway-server.com:8888"

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -53,7 +53,8 @@ RUN dpkg --purge --force-depends ca-certificates-java \
     software-properties-common \
     openssh-server \
     openssh-client \
-    && apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' \
+    && apt-add-repository 'deb http://security.debian.org/debian-security bullseye-security main' \
+    && apt-add-repository 'deb http://deb.debian.org/debian/ sid main' \
     && apt-get update && apt-get install -yq --no-install-recommends  \
     openjdk-8-jre-headless \
     ca-certificates-java \

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -1,6 +1,6 @@
 # Ubuntu:Bionic
 # TensorFlow 2.4.0
-ARG BASE_CONTAINER=jupyter/tensorflow-notebook:2023-03-13
+ARG BASE_CONTAINER=jupyter/tensorflow-notebook:2023-10-20
 
 FROM $BASE_CONTAINER
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.5"]
+requires = ["hatchling>=1.21.1"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ jupyter-enterprisegateway = "enterprise_gateway.enterprisegatewayapp:launch_inst
 [project.optional-dependencies]
 test = [
   "coverage",
-  "pytest",
+  "pytest<8.1.0",
   "pytest-tornasync",
   "ipykernel",
   "pre-commit",


### PR DESCRIPTION
Docker fixes:
- Update Debian security repository for the demo-base docker image
- Use more recent TensorFlow base image as old one is unavailable

Fixes #1371