### PR TITLE
Check kernel id before delete and upgrade ws

### DIFF
--- a/enterprise_gateway/services/kernels/handlers.py
+++ b/enterprise_gateway/services/kernels/handlers.py
@@ -146,6 +146,24 @@ class KernelHandler(
         model = km.kernel_model(kernel_id)
         self.finish(json.dumps(model, default=date_default))
 
+    @web.authenticated
+    async def delete(self, kernel_id):
+        """Remove a kernel."""
+        self.kernel_manager.check_kernel_id(kernel_id=kernel_id)
+        await super().delete(kernel_id=kernel_id)
+
+
+class ZMQChannelsHandler(
+    TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin, jupyter_server_handlers.ZMQChannelsHandler
+):
+    """Extends the kernel websocket handler."""
+
+    async def get(self, kernel_id):
+        """Handle a get request for a kernel."""
+        # Synchronize Kernel and check if it exists.
+        self.kernel_manager.check_kernel_id(kernel_id=kernel_id)
+        await super().get(kernel_id=kernel_id)
+
 
 default_handlers: list[tuple] = []
 for path, cls in jupyter_server_handlers.default_handlers:


### PR DESCRIPTION
* **Description:** When Kubernetes is in replication availability mode, deleting the kernel or creating a WebSocket connection may cause a 404 error due to unsynchronized sessions.

* **Related issue:** #1373