### PR TITLE
Resolve periodic socket.timeout causing control channel socket recycling

### DIFF
--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -6,12 +6,14 @@ import json
 import logging
 import os
 import random
+import select
 import signal
 import socket
 import tempfile
 import uuid
 from multiprocessing import Process
 from threading import Thread
+from typing import Optional, Dict, Any
 
 from Cryptodome.Cipher import AES, PKCS1_v1_5
 from Cryptodome.PublicKey import RSA
@@ -344,30 +346,34 @@ def _get_candidate_port(lower_port, upper_port):
     return random.randint(lower_port, upper_port)
 
 
-def get_server_request(sock):
+def get_server_request(sock: socket.socket) -> Optional[Dict[str, Any]]:
     """Gets a request from the server and returns the corresponding dictionary.
 
     This code also exists in the R kernel-launcher's server_listener.py script.
     """
-    conn = None
-    data = ""
-    request_info = None
+    conn: Optional[socket.socket] = None
     try:
-        conn, addr = sock.accept()
-        while True:
-            buffer = conn.recv(1024).decode("utf-8")
-            if not buffer:  # send is complete
-                request_info = json.loads(data)
-                break
-            data = data + buffer  # append what we received until we get no more...
-    except Exception as e:
-        if type(e) is not socket.timeout:
-            raise e
+        # Enterprise gateway establishes a new connection for every request.
+        # Wait until a new connection is made, before accepting and reading.
+        input_ready, _, except_ready = select.select([sock], [], [])
+        for sock_ready in input_ready:
+            conn, addr = sock_ready.accept()
+            logger.info(f"Accepted connection on control channel from {addr=}")
+            data: str = ""
+            while buffer := conn.recv(1024).decode("utf-8"):
+                data = data + buffer  # append what we received until we get no more...
+            return json.loads(data) if data else None
+
+        if except_ready:
+            logger.error("Control channel sock reported error state")
+
+    except Exception:
+        logger.exception("Control channel socket closed unexpectedly")
     finally:
         if conn:
             conn.close()
 
-    return request_info
+    return None
 
 
 def cancel_spark_jobs(sig, frame):


### PR DESCRIPTION
For every message send from the Enterprise Gateway to the kernel, a new connection is accepted using `socket.accept()`. The timeout for this socket is 5 seconds: https://github.com/jupyter-server/enterprise_gateway/blob/d01e84a2457d44d14bd6bd3335307b9d0e3b483d/etc/kernel-launchers/python/scripts/launch_ipykernel.py#L293

Instead of restarting the blocking `accept` call, we can use `select.select` to check ready-state of the socket. Using this method we don't cycle the connection and delay (or miss) messages.