### PR TITLE
Feature/configure kernel launch terminate on events

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -11,14 +11,16 @@ import re
 import signal
 import time
 import uuid
+import json
 from typing import Any, ClassVar
 
 from jupyter_client.ioloop.manager import AsyncIOLoopKernelManager
 from jupyter_client.kernelspec import KernelSpec
 from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager
 from tornado import web
-from traitlets import directional_link
+from traitlets import directional_link, default
 from traitlets import log as traitlets_log
+from traitlets import List as ListTrait
 from zmq import IO_THREADS, MAX_SOCKETS, Context
 
 from enterprise_gateway.mixins import EnterpriseGatewayConfigMixin
@@ -160,6 +162,21 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
     """
     Extends the AsyncMappingKernelManager with support for managing remote kernels via the process-proxy.
     """
+
+    kernel_launch_terminate_on_events_env = "EG_KERNEL_LAUNCH_TERMINATE_ON_EVENTS"
+    kernel_launch_terminate_on_events_default_value = []
+    kernel_launch_terminate_on_events = ListTrait(
+        default_value=kernel_launch_terminate_on_events_default_value,
+        config=True,
+        help="""Comma-separated list of dictionaries, each describing an event by `type`, `reason`,
+         and `timeout_in_seconds` (e.g. [{"type": "Warning", "reason": "FailedMount", "timeout_in_seconds": 0}]).
+         Kernel pod events will be sampled during startup, and if an event described in this list is detected,
+         the kernel launch will be terminated after the set timeout. Only available for container kernels. """
+    )
+
+    @default("kernel_launch_terminate_on_events")
+    def _kernel_launch_terminate_on_events_default(self) -> list:
+        return json.loads(os.getenv(self.kernel_launch_terminate_on_events_env, "[]"))
 
     def _context_default(self) -> Context:
         """

--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import abc
 import os
 import signal
+from collections import defaultdict
 from typing import Any
 
 import urllib3  # docker ends up using this and it causes lots of noise, so turn off warnings
@@ -46,6 +47,14 @@ class ContainerProcessProxy(RemoteProcessProxy):
         super().__init__(kernel_manager, proxy_config)
         self.container_name = ""
         self.assigned_node_ip = None
+        self._initialize_kernel_launch_terminate_on_events()
+
+    def _initialize_kernel_launch_terminate_on_events(self):
+        self.kernel_launch_terminate_on_events = defaultdict(dict)
+        for configuration in self.kernel_manager.parent.kernel_launch_terminate_on_events:
+            self.kernel_launch_terminate_on_events[
+                configuration["type"]
+            ][configuration["reason"]] = configuration["timeout_in_seconds"]
 
     def _determine_kernel_images(self, **kwargs: dict[str, Any] | None) -> None:
         """

--- a/enterprise_gateway/services/processproxies/k8s.py
+++ b/enterprise_gateway/services/processproxies/k8s.py
@@ -110,6 +110,18 @@ class KubernetesProcessProxy(ContainerProcessProxy):
 
         return pod_status
 
+    def get_container_events(self) -> list:
+        """Return container events"""
+        pod_events = []
+        core_v1_api = client.CoreV1Api()
+        if self.container_name:
+            ret = core_v1_api.list_namespaced_event(
+                namespace=self.kernel_namespace, field_selector=f"involvedObject.name={self.container_name}"
+            )
+            if ret and ret.items:
+                pod_events = ret.items
+        return pod_events
+
     def delete_managed_object(self, termination_stati: list[str]) -> bool:
         """Deletes the object managed by this process-proxy
 


### PR DESCRIPTION
This pull request adds the option to configure kernel container events which should cause a termination of the kernel launch process. 
The user can now configure "unresolvable" events, to prevent a long wait for the timeout when such events occur.
It also allows the users to set a different timeout for some events, in example when a user knows an event may resolve after a small wait, but if it didn't, they want to terminate the kernel launch process.  