### PR TITLE
change V1Subject to RbacV1Subject in k8s.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ clean-env: ## Remove conda env
 lint: ## Check code style
 	@pip install -q -e ".[lint]"
 	@pip install -q pipx
-	ruff .
+	ruff check .
 	black --check --diff --color .
 	mdformat --check *.md
 	pipx run 'validate-pyproject[all]' pyproject.toml

--- a/enterprise_gateway/services/processproxies/k8s.py
+++ b/enterprise_gateway/services/processproxies/k8s.py
@@ -349,7 +349,7 @@ class KubernetesProcessProxy(ContainerProcessProxy):
         binding_role_ref = client.V1RoleRef(
             api_group="", kind="ClusterRole", name=kernel_cluster_role
         )
-        binding_subjects = client.V1Subject(
+        binding_subjects = client.RbacV1Subject(
             api_group="", kind="ServiceAccount", name=service_account_name, namespace=namespace
         )
 


### PR DESCRIPTION
This change fix - Error: module 'kubernetes.client' has no attribute 'V1Subject'

This error occurs when an attempt is made to create a role binding.
The full error looks as follows:
```
[E 2024-06-03 08:58:36.252 EnterpriseGatewayApp] Error occurred creating role binding for namespace 'jovyan-153ca7c1-c68f-440d-b678-f8926b48afbc': module 'kubernetes.client' has no attribute 'V1Subject'
```