### PR TITLE
Handle exceptions in the `load_session`

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -197,7 +197,11 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
 
     def _refresh_kernel(self, kernel_id: str) -> bool:
         if self.parent.availability_mode == EnterpriseGatewayConfigMixin.AVAILABILITY_REPLICATION:
-            self.parent.kernel_session_manager.load_session(kernel_id)
+            try:
+                self.parent.kernel_session_manager.load_session(kernel_id)
+            except Exception as e:
+                self.log.error(f"Failed to load session, kernel_id:{kernel_id}", e)
+                return False
             return self.parent.kernel_session_manager.start_session(kernel_id)
         # else we should throw 404 when not using an availability mode of 'replication'
         return False


### PR DESCRIPTION
When refreshing the kernel, there might be other exceptions causing the refresh to fail. Perhaps catching exceptions would be more elegant.

For example: 
	When querying a non-existent kernel, the  `load_session` method from the` webhook` returns a `404` error. If this is not handled, the final API response is a `500` error, whereas the expected response is a `404`.