### PR TITLE
Win Support for LocalProcessProxy

### DIFF
--- a/enterprise_gateway/services/kernels/handlers.py
+++ b/enterprise_gateway/services/kernels/handlers.py
@@ -58,7 +58,17 @@ class MainKernelHandler(
                 raise tornado.web.HTTPError(400)
 
             # Transfer inherited environment variables from current process
-            env = {key: value for key, value in os.environ.items() if key in self.inherited_envs}
+            if os.name == "nt":
+                # We need to ensure we pass all needed environment variables to the kernel
+                # Users can use inherited_envs to add custom envrioment variables,
+                # and we ensure PATH, SYSTEMROOT, TEMP, USERPROFILE, WINDIR, COMSPEC, APPDATA, LOCALAPPDATA, PROGRAMDATA and PROGRAMFILES are included
+                # this allows a more out-of-the-box experience for users
+                required_envs: set[str] = {"PATH", "SYSTEMROOT", "TEMP", "USERPROFILE", "WINDIR", "COMSPEC",
+                                           "APPDATA", "LOCALAPPDATA", "PROGRAMDATA", "PROGRAMFILES"}
+                env = {key: value for key, value in os.environ.items() if
+                       key in self.inherited_envs or key in required_envs}
+            else:
+                env = {key: value for key, value in os.environ.items() if key in self.inherited_envs}
 
             # Allow all KERNEL_* envs and those specified in client_envs and set from client.  If this EG
             # instance is configured to accept all envs in the payload (i.e., client_envs == '*'), go ahead

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -1043,6 +1043,8 @@ class LocalProcessProxy(BaseProcessProxyABC):
         """Initialize the proxy."""
         super().__init__(kernel_manager, proxy_config)
         kernel_manager.ip = localinterfaces.LOCALHOST
+        if os.name == "nt":
+            self.win32_interrupt_event = None
 
     async def launch_process(
         self, kernel_cmd: str, **kwargs: dict[str, Any] | None
@@ -1059,6 +1061,8 @@ class LocalProcessProxy(BaseProcessProxyABC):
             except OSError:
                 pass
         self.ip = local_ip
+        if os.name == "nt": # if operating system is Windows then link the win32_interrupt_event from the kernel
+            self.win32_interrupt_event = self.local_proc.win32_interrupt_event
         self.log.info(
             "Local kernel launched on '{}', pid: {}, pgid: {}, KernelID: {}, cmd: '{}'".format(
                 self.ip, self.pid, self.pgid, self.kernel_id, kernel_cmd


### PR DESCRIPTION
Hi,

As discussed in issue #1394 , I am submitting this Pull Request.

In the meantime, I managed to correctly link the `win32_interrupt_event`, resulting in a working patch. This implementation has been tested successfully on Windows Server 2019 and Windows 11.

### Key Changes:
1. Added the required environment variables in `enterprise_gateway/services/kernels/handlers.py` to provide users with an out-of-the-box experience.
2. Linked the interrupt event for Windows in the `LocalProcessProxy` class.
   - This could potentially be refactored into the base class in the future. However, for now, I have implemented it in `LocalProcessProxy`, as I was only able to test local processes. I might be able to test `RemoteProcessProxy` soon.

Please let me know your thoughts on these changes or any adjustments you'd like to see.
